### PR TITLE
feat: Add network-based party quest sync

### DIFF
--- a/.github/prompts/plan-networkBasedPartyQuestSync.prompt.md
+++ b/.github/prompts/plan-networkBasedPartyQuestSync.prompt.md
@@ -1,0 +1,329 @@
+# Plan: Network-Based Party Quest Sync
+
+Add addon communication to track party members' quest states (IDs, completions, turn-ins) with a persistent quest name cache. Display "Wrapping Up" (recently turned in) and "Kicking Off" (recently accepted) sections in the quest window, with configurable display options and 10-minute default lookback in the options panel.
+
+## Steps
+
+1. **Implement addon message protocol in `QuestCoop.lua`**: Register `CHAT_MSG_ADDON` and `QUEST_TURNED_IN` events, define message types (`QUEST_LOG`, `QUEST_COMPLETE`, `QUEST_TURNIN`, `QUEST_ACCEPT`, `REQUEST_SYNC`), add throttled broadcast using `SendAddonMessage("QuestCoop", payload, "PARTY")` chunking quest lists to 10 IDs per message with 1-second frame-based queue delays between chunks.
+
+2. **Build persistent quest name cache**: Add `QuestCoopDB.questCache = { [questID] = {name="...", timestamp=time()} }` with 30-day expiration on load, populate via `C_QuestLog.GetTitleForQuestID()` with `C_QuestLog.RequestLoadQuestByID()` fallback, register `QUEST_DATA_LOAD_RESULT` event to handle async name fetches, implement cache cleanup function removing entries where `time() - timestamp > 2592000` (30 days).
+
+3. **Track party member quest states and broadcast**: Store runtime `questsByPlayer[playerName] = { activeQuestIDs={...}, wrappingUp={{questID, timestamp},...}, kickingOff={{questID, timestamp},...} }`, handle incoming addon messages to reconstruct multi-chunk `QUEST_LOG` broadcasts and update remote player data, send full quest log on `GROUP_ROSTER_UPDATE` (chunked, 1s delays), send instant `QUEST_ACCEPT` message on `QUEST_ACCEPTED` event, send instant `QUEST_TURNIN` message on `QUEST_TURNED_IN` event. **Trigger UI refresh after processing incoming messages**: call debounced `QueueDisplayRefresh()` after updating `partyQuestStates` to prevent UI flicker during multi-chunk syncs.
+
+4. **Add "Wrapping Up" and "Kicking Off" sections to quest window**: Insert new sections in `CreateQuestWindow()` after shared quests section: "Wrapping Up (X quests)" showing party member turn-ins where local player still has the quest, "Kicking Off (Y quests)" showing party member recent accepts where local player doesn't have the quest, filter both by `timestamp >= (time() - lookbackMinutes*60)`, use orange color for "Wrapping Up" and cyan color for "Kicking Off" headers, display player names per quest row.
+
+5. **Extend options panel with visibility toggles and lookback setting**: Add "Display Sections" checkboxes in `settingsPanel` for "Wrapping Up", "Kicking Off", "Shared Quests", "My Unique Quests", "Party Unique Quests" (all default enabled), add slider/editbox for "Recent Activity Lookback (minutes)" with range 5-120 and default 10 minutes, save to `QuestCoopDB.settings.visibleSections` table and `QuestCoopDB.settings.recentLookbackMinutes`, update `RefreshQuestWindowIfVisible()` to respect visibility toggles.
+
+## Further Considerations
+
+1. **Message payload format**: - Use compact colon-and-comma format: `QUEST_LOG:1:5:12345,67890,...`. This stays well under 255 bytes (~73 bytes for 10 IDs) and is trivial to parse with `strsplit(":", payload)` and `strsplit(",", idString)`. Avoid JSON/table serialization overhead.
+
+2. **Handling players leaving party**:  - Retain `partyQuestStates` entry for **5 minutes** after player leaves party (mark `inParty=false`, track `lastUpdate` timestamp). This handles DC/reconnect gracefully without forcing full re-sync. Purge entries older than 5-minute grace period on `GROUP_ROSTER_UPDATE`. Optional: make grace period configurable (0-15 min range, 0 = immediate clear for users who want strict cleanup).
+
+3. **Quest name cache size management**:  - Rely **solely on 30-day expiration** (cleanup on `PLAYER_LOGIN`). No hard cap needed—most players won't accumulate enough unique quest IDs in 30 days to cause SavedVariables bloat. Even completionists doing 5000+ quests will naturally purge old entries. Simpler code, better performance. Optional: Add debug stat in settings panel showing cache size for troubleshooting.
+
+4. **Multi-chunk message reconstruction**: When receiving chunked `QUEST_LOG` messages, store partial data in `incomingChunks[playerName][chunkIndex] = payload`. Once all chunks received (check `chunkIndex == totalChunks`), concatenate and parse full quest list. Handle missing chunks (timeout after 30 seconds, request re-sync).
+
+5. **Version compatibility**: If protocol changes in future (e.g., adding quest progress %), prefix messages with version: `v1:QUEST_LOG:...`. Addon ignores messages with unknown version prefix, preventing parse errors across addon updates.
+
+6. **UnitFullName API**: Use `local name, realm = UnitFullName(unit)` which returns name and realm separately. If `realm == nil` (same realm as player), construct key as `name .. "-" .. GetRealmName()`. If `realm ~= nil`, construct as `name .. "-" .. realm`. This ensures consistent `"Name-Realm"` format across all scenarios (same-realm, cross-realm, sender from addon message).
+
+## User Requirements Summary
+
+- **Network messaging**: Use addon message protocol to sync quest data between party members
+- **Quest tracking**: Track active quests, recent turn-ins, recent accepts for all party members
+- **Quest name cache**: Persistent cache with 30-day expiration in SavedVariables
+- **Message throttling**: 10 quest IDs per message, 1-second delay between messages
+- **Display sections**:
+  - "Wrapping Up": Recently turned in by party (where local player still has quest)
+  - "Kicking Off": Recently accepted by party (where local player doesn't have quest)
+  - Existing: Shared quests, My unique quests, Party unique quests
+- **Configuration**:
+  - Lookback time: 5-120 minutes (default 10)
+  - Section visibility toggles for all 5 sections
+- **Event usage**: `QUEST_TURNED_IN` for turn-in detection
+
+## Technical Specifications
+
+### Message Protocol
+
+**Prefix**: `"QuestCoop"`
+**Channel**: `"PARTY"`
+**Critical Constraint**: WoW addon messages limited to **255 bytes per message**
+
+**Message Types**:
+- `QUEST_LOG`: Full quest list (chunked)
+  - Format: `QUEST_LOG:<chunkIndex>:<totalChunks>:<questID1>,<questID2>,...`
+  - Max 10 IDs per chunk (safely under 255 bytes: ~20 char prefix + 50 chars for IDs + 9 commas = ~80 bytes)
+  - Example: `QUEST_LOG:1:5:12345,67890,11111,22222,33333,44444,55555,66666,77777,88888`
+- `QUEST_ACCEPT`: Single quest accepted
+  - Format: `QUEST_ACCEPT:<questID>:<timestamp>`
+  - Example: `QUEST_ACCEPT:12345:1732492800`
+- `QUEST_TURNIN`: Single quest turned in
+  - Format: `QUEST_TURNIN:<questID>:<timestamp>`
+  - Example: `QUEST_TURNIN:12345:1732492800`
+- `REQUEST_SYNC`: Request full quest log from party
+  - Format: `REQUEST_SYNC`
+
+### Data Structures
+
+**Saved Variables (persistent)**:
+```lua
+QuestCoopDB = {
+  settings = {
+    textSize = "small" | "medium" | "large",
+    recentLookbackMinutes = 10,  -- NEW
+    visibleSections = {          -- NEW
+      wrappingUp = true,
+      kickingOff = true,
+      sharedQuests = true,
+      myQuests = true,
+      partyQuests = true
+    }
+  },
+  printButtonPos = { ... },
+  questCache = {                 -- NEW
+    [questID] = {
+      name = "Quest Title",
+      timestamp = 1234567890
+    }
+  }
+}
+```
+
+**Runtime Variables (in-memory)**:
+```lua
+-- Party member quest states (keyed by full "PlayerName-Realm" string)
+partyQuestStates = {
+  ["PlayerName-Realm"] = {
+    activeQuestIDs = { [12345] = true, [67890] = true },
+    wrappingUp = {
+      { questID = 11111, timestamp = 1234567890 },
+      { questID = 22222, timestamp = 1234567891 }
+    },
+    kickingOff = {
+      { questID = 33333, timestamp = 1234567892 }
+    },
+    lastUpdate = 1234567890,  -- time() of last message/roster check
+    inParty = true            -- false = player left, retained for DC grace period
+  }
+}
+
+-- Incoming multi-chunk message reconstruction buffer
+incomingChunks = {
+  ["PlayerName-Realm"] = {
+    [1] = "12345,67890,...",  -- chunk index -> payload
+    [2] = "44444,55555,...",
+    totalChunks = 5,
+    receivedAt = 1234567890   -- timeout detection
+  }
+}
+
+-- Message queue for throttling (global across all message types)
+messageQueue = {
+  { type = "QUEST_LOG", chunk = 1, total = 5, payload = "12345,67890,..." },
+  { type = "QUEST_ACCEPT", payload = "QUEST_ACCEPT:12345:1732492800" },
+  { type = "QUEST_LOG", chunk = 2, total = 5, payload = "44444,55555,..." }
+}
+
+-- Global message cooldown tracker
+lastMessageSentTime = 0  -- time() of last SendAddonMessage call
+MESSAGE_COOLDOWN = 1.0   -- 1 second minimum between ANY addon messages
+
+-- Stale data retention settings
+STALE_DATA_RETENTION = 300  -- 5 minutes (300 seconds) grace period for DC/reconnects
+
+-- UI refresh debouncing
+pendingDisplayRefresh = false  -- flag indicating refresh is queued
+lastDisplayRefreshTime = 0     -- time() of last actual refresh
+DISPLAY_REFRESH_DEBOUNCE = 0.1 -- 100ms debounce window
+```
+
+### Event Handlers
+
+**New events to register**:
+- `CHAT_MSG_ADDON`: Receive addon messages
+- `QUEST_TURNED_IN`: Detect quest turn-ins
+- `QUEST_DATA_LOAD_RESULT`: Handle async quest name lookups
+
+**Modified event handlers**:
+- `QUEST_ACCEPTED`: Queue instant `QUEST_ACCEPT` message (respects global cooldown)
+- `QUEST_TURNED_IN`: Queue instant `QUEST_TURNIN` message (respects global cooldown)
+- `GROUP_ROSTER_UPDATE`: 
+  1. Iterate party units, capture full names via `UnitFullName(unit)`
+  2. Update `partyQuestStates` entries: mark active players `inParty=true`, inactive as `inParty=false`
+  3. Purge stale entries (inactive > 5 min grace period)
+  4. Queue full quest log sync with **random 0-5 second jitter** (skip if player already has cached data within grace period)
+- `PLAYER_LOGIN`: Add cache cleanup (30-day expiration) and initialize message queue/cooldown tracker
+- `CHAT_MSG_ADDON`: 
+  1. Extract sender (already `"Name-Realm"`), parse message type
+  2. Handle `QUEST_ACCEPT`/`QUEST_TURNIN`: Add to `partyQuestStates[sender].kickingOff`/`wrappingUp`
+  3. Handle `QUEST_LOG` chunk: Store in `incomingChunks[sender][chunkIndex]`, check if complete
+  4. If QUEST_LOG complete: Reconstruct full list, update `partyQuestStates[sender].activeQuestIDs`
+  5. After ANY state update: Call `QueueDisplayRefresh()` to trigger debounced UI update
+
+### UI Layout Changes
+
+**New sections in quest window** (in order):
+1. Shared Quests (existing)
+2. **Wrapping Up** (new) - orange header
+3. **Kicking Off** (new) - cyan header
+4. My Unique Quests (existing)
+5. Party Unique Quests (existing)
+
+Each section respects visibility toggle from settings.
+
+### Cache Management
+
+**Quest name resolution**:
+1. Check `QuestCoopDB.questCache[questID]`
+2. If miss, try `C_QuestLog.GetTitleForQuestID(questID)`
+3. If nil, call `C_QuestLog.RequestLoadQuestByID(questID)` and wait for `QUEST_DATA_LOAD_RESULT`
+4. Cache result with current timestamp
+
+**Cleanup logic** (on `PLAYER_LOGIN`):
+- Iterate `QuestCoopDB.questCache`
+- Remove entries where `time() - entry.timestamp > 2592000` (30 days)
+- **No hard cap**: 30-day expiration is sufficient for normal usage (most players won't accumulate problematic cache sizes)
+
+### Message Throttling
+
+**Global Cooldown Queue-based Approach**:
+
+**Rationale**: WoW enforces a 255-byte message limit and server-side rate limiting. Multiple party members syncing simultaneously (e.g., on party formation) can overwhelm the server and cause message loss or throttling penalties.
+
+**Strategy**:
+1. **Single Global Queue**: All addon messages (QUEST_LOG chunks, QUEST_ACCEPT, QUEST_TURNIN) go into one `messageQueue`
+2. **Global 1-Second Cooldown**: Track `lastMessageSentTime`. Only send next message if `time() - lastMessageSentTime >= MESSAGE_COOLDOWN` (1.0 seconds)
+3. **OnUpdate Processor**: Frame `OnUpdate` checks queue head, compares cooldown, sends if ready, updates `lastMessageSentTime`, removes from queue
+4. **Sync Jitter**: On `GROUP_ROSTER_UPDATE`, add random delay (0-5 seconds) before queuing quest log to desynchronize party-wide broadcasts and prevent sync storms
+5. **Chunk Generation**: Split quest log into chunks of 10 quest IDs (~80 bytes each, safely under 255-byte limit)
+
+**Benefits**:
+- Prevents flooding during party formation (5 players × 5 chunks = 25 messages spread over 25+ seconds)
+- Gracefully handles reconnects without overwhelming server
+- Ensures instant messages (QUEST_ACCEPT/TURNIN) don't get dropped due to concurrent chunk sends
+- Random jitter prevents thundering herd when multiple players join simultaneously
+
+**Example Timeline**:
+- T+0s: Player joins party, rolls random delay (e.g., 2.7s)
+- T+2.7s: Queue 5 QUEST_LOG chunks
+- T+2.7s: Send chunk 1 (cooldown starts)
+- T+3.7s: Send chunk 2
+- T+4.7s: Send chunk 3
+- T+5.2s: Player accepts new quest, QUEST_ACCEPT queued
+- T+5.7s: Send chunk 4
+- T+6.7s: Send QUEST_ACCEPT
+- T+7.7s: Send chunk 5
+
+### Display Logic
+
+**Wrapping Up section**:
+- Iterate all party members' `wrappingUp` lists
+- Filter: `timestamp >= (time() - lookbackMinutes * 60)`
+- Filter: local player still has quest in log (`C_QuestLog.IsOnQuest(questID)`)
+- Display: Quest ID, quest name (from cache), player name who turned it in
+- Tooltip: "PlayerName turned this in X minutes ago"
+
+**Kicking Off section**:
+- Iterate all party members' `kickingOff` lists
+- Filter: `timestamp >= (time() - lookbackMinutes * 60)`
+- Filter: local player does NOT have quest (`not C_QuestLog.IsOnQuest(questID)`)
+- Display: Quest ID, quest name (from cache), player name who accepted
+- Tooltip: "PlayerName picked this up X minutes ago"
+
+**Filter Logic Validation**:
+- ✅ **Wrapping Up filter is correct**: Only show quests local player still has (should turn in next)
+- ✅ **Kicking Off filter is correct**: Only show quests local player doesn't have (may want to pick up)
+- **Rationale**: These filters provide high-value, actionable information—highlighting coordination opportunities without UI clutter
+
+## Implementation Notes
+
+### Message Size Verification
+- **255-Byte Limit**: Each `SendAddonMessage()` call must stay under 255 bytes
+- **Payload Calculation**: For `QUEST_LOG:1:5:12345,67890,...` with 10 five-digit IDs:
+  - Prefix: "QUEST_LOG:" = 10 bytes
+  - Chunk metadata: "1:5:" = 4 bytes (worst case: "99:99:" = 6 bytes)
+  - Quest IDs: 10 × 5 digits = 50 bytes
+  - Commas: 9 bytes
+  - **Total**: ~73 bytes (safely under 255 bytes)
+- **Safety Check**: Before sending, verify `#payload <= 250` to leave margin for encoding overhead
+
+### UI Refresh & Debouncing
+
+**Problem**: Incoming messages update `partyQuestStates` frequently (multi-chunk `QUEST_LOG` syncs, rapid `QUEST_ACCEPT`/`QUEST_TURNIN` events). Refreshing UI immediately after each message causes flicker and performance issues.
+
+**Solution**: Debounced refresh mechanism
+
+**Implementation**:
+```lua
+function QueueDisplayRefresh()
+  if not pendingDisplayRefresh then
+    pendingDisplayRefresh = true
+    -- Frame OnUpdate will handle actual refresh after debounce window
+  end
+end
+
+-- In Frame OnUpdate handler:
+if pendingDisplayRefresh and (time() - lastDisplayRefreshTime >= DISPLAY_REFRESH_DEBOUNCE) then
+  pendingDisplayRefresh = false
+  lastDisplayRefreshTime = time()
+  RefreshQuestWindowIfVisible()  -- Existing function, only refreshes if window open
+end
+```
+
+**Benefits**:
+- **Multi-chunk sync**: 5 QUEST_LOG chunks arrive over 1-5 seconds, UI refreshes once 100ms after last chunk
+- **Rapid events**: Multiple QUEST_ACCEPT messages in quick succession refresh once, not N times
+- **Performance**: Prevents unnecessary layout recalculations during message bursts
+- **User experience**: No UI flicker, smooth updates
+
+**Trigger Points** (call `QueueDisplayRefresh()` after):
+- Processing any `CHAT_MSG_ADDON` that updates `partyQuestStates`
+- Completing multi-chunk `QUEST_LOG` reconstruction
+- Receiving instant `QUEST_ACCEPT`/`QUEST_TURNIN` messages
+- `GROUP_ROSTER_UPDATE` (after roster/stale data updates)
+- Local player events: `QUEST_ACCEPTED`, `QUEST_TURNED_IN`, `QUEST_REMOVED`
+
+**Edge Case**: If window is closed, `RefreshQuestWindowIfVisible()` no-ops (existing behavior preserved)
+
+### Player Identification & Stale Data Management
+
+**Player Name Resolution**:
+- **Full Name Key**: Always use `"PlayerName-Realm"` format as the key for `partyQuestStates`
+- **Capture on Events**:
+  - On `GROUP_ROSTER_UPDATE`: Iterate party units (`"party1"` through `"party4"`), call `UnitFullName(unit)` to get `"Name-Realm"` string
+  - On `CHAT_MSG_ADDON`: Extract sender parameter (already in `"Name-Realm"` format)
+- **Rationale**: Full name-realm ensures uniqueness and allows retention after player leaves party (for DC grace period)
+
+**Stale Data Retention (DC/Reconnect Handling)**:
+- On `GROUP_ROSTER_UPDATE`:
+  1. Build list of current party members (full names)
+  2. For each entry in `partyQuestStates`:
+     - If player in current roster: set `inParty = true`, update `lastUpdate = time()`
+     - If player NOT in roster but `inParty == true`: set `inParty = false`, keep `lastUpdate` timestamp
+  3. **Grace Period Cleanup**: Remove entries where `inParty == false` AND `time() - lastUpdate > STALE_DATA_RETENTION` (5 minutes)
+- **Benefit**: Player who DCs and reconnects within 5 minutes retains their "Wrapping Up"/"Kicking Off" history without re-sync delay
+- **Alternative**: Make retention time configurable in settings (default 5 min, range 0-15 min, 0 = immediate clear)
+
+**Sync Storm Prevention**:
+- On `GROUP_ROSTER_UPDATE`, add `math.random(0, 5000) / 1000` second delay before queuing quest log sync
+- On DC/reconnect, same random jitter applies (prevents repeated storms)
+- Do NOT queue sync if player's data still exists in `partyQuestStates` (they're within grace period)
+
+### Protocol Versioning
+- Implement message version prefix for future protocol changes: `v1:QUEST_LOG:...`
+- Ignore messages from incompatible versions (parse version, compare to current)
+
+### Debugging
+- Add debug logging toggle in settings (default: off)
+- Log: message queue size, cooldown remaining, chunk send/receive events
+- Display queue size in settings panel for visibility into sync backlog
+
+### Testing Scenarios
+- **5-player party formation**: Verify ~25+ second sync time (5 players × 5 chunks × 1s + jitter)
+- **Mid-dungeon DC**: Verify rejoining player doesn't cause UI freezes or message loss
+- **Rapid quest accepts**: Verify instant messages don't get dropped behind slow chunk sync
+- **50+ quest log**: Verify chunking handles edge cases (exact 10 IDs, 1 remaining ID, etc.)
+- **UI refresh performance**: Verify no flicker during multi-chunk sync (should refresh once after final chunk, not 5 times)
+- **Debounce validation**: Accept 3 quests rapidly (<1 second apart), verify UI refreshes once ~100ms after last accept

--- a/src/QuestCoop.lua
+++ b/src/QuestCoop.lua
@@ -3,7 +3,30 @@ local addonName, addon = ...
 -- Default settings
 local DEFAULT_SETTINGS = {
     textSize = "medium", -- small, medium, large
+    recentLookbackMinutes = 10, -- How far back to look for "recent" quest activity
+    visibleSections = {
+        wrappingUp = true,
+        kickingOff = true,
+        sharedQuests = true,
+        myQuests = true,
+        partyQuests = true,
+    },
 }
+
+-- Network protocol constants
+local ADDON_PREFIX = "QuestCoop"
+local MESSAGE_COOLDOWN = 1.0 -- 1 second between messages
+local STALE_DATA_RETENTION = 300 -- 5 minutes (300 seconds)
+local DISPLAY_REFRESH_DEBOUNCE = 0.1 -- 100ms debounce for UI updates
+local QUEST_CACHE_EXPIRATION = 2592000 -- 30 days in seconds
+
+-- Runtime data structures
+local partyQuestStates = {} -- ["PlayerName-Realm"] = {activeQuestIDs, wrappingUp, kickingOff, lastUpdate, inParty}
+local incomingChunks = {} -- ["PlayerName-Realm"] = {[chunkIndex] = payload, totalChunks, receivedAt}
+local messageQueue = {} -- Array of {type, payload, chunk, total}
+local lastMessageSentTime = 0
+local pendingDisplayRefresh = false
+local lastDisplayRefreshTime = 0
 
 local function ShortName(name)
     if not name then return "?" end
@@ -35,6 +58,122 @@ local function GetFontSize()
     else -- medium
         return "GameFontHighlightSmall", "GameFontNormal", "GameFontNormalLarge"
     end
+end
+
+-- Quest name cache management
+local function GetQuestName(questID)
+    -- Check cache first
+    if QuestCoopDB.questCache and QuestCoopDB.questCache[questID] then
+        return QuestCoopDB.questCache[questID].name
+    end
+    
+    -- Try to get from API
+    local name = C_QuestLog.GetTitleForQuestID(questID)
+    if name then
+        -- Cache it
+        if not QuestCoopDB.questCache then QuestCoopDB.questCache = {} end
+        QuestCoopDB.questCache[questID] = {name = name, timestamp = time()}
+        return name
+    end
+    
+    -- Request load if not available
+    C_QuestLog.RequestLoadQuestByID(questID)
+    return "Quest " .. questID -- Placeholder until loaded
+end
+
+local function CleanupQuestCache()
+    if not QuestCoopDB.questCache then return end
+    local currentTime = time()
+    local removed = 0
+    for questID, data in pairs(QuestCoopDB.questCache) do
+        if currentTime - data.timestamp > QUEST_CACHE_EXPIRATION then
+            QuestCoopDB.questCache[questID] = nil
+            removed = removed + 1
+        end
+    end
+    if removed > 0 then
+        print("QuestCoop: Cleaned up " .. removed .. " expired quest cache entries")
+    end
+end
+
+-- Player identification helper
+local function GetFullPlayerName(unit)
+    local name, realm = UnitFullName(unit)
+    if not name then return nil end
+    if not realm or realm == "" then
+        realm = GetRealmName()
+    end
+    return name .. "-" .. realm
+end
+
+-- Message queue and throttling
+local function QueueMessage(msgType, payload, chunk, total)
+    table.insert(messageQueue, {
+        type = msgType,
+        payload = payload,
+        chunk = chunk,
+        total = total
+    })
+end
+
+local function SendQueuedMessages(elapsed)
+    if #messageQueue == 0 then return end
+    
+    local currentTime = time()
+    if currentTime - lastMessageSentTime >= MESSAGE_COOLDOWN then
+        local msg = table.remove(messageQueue, 1)
+        if msg then
+            -- Safety check: ensure payload is under 250 bytes
+            if #msg.payload <= 250 then
+                C_ChatInfo.SendAddonMessage(ADDON_PREFIX, msg.payload, "PARTY")
+                lastMessageSentTime = currentTime
+            else
+                print("QuestCoop: Warning - Message too large (" .. #msg.payload .. " bytes), skipped")
+            end
+        end
+    end
+end
+
+-- Broadcast quest log in chunks
+local function BroadcastQuestLog()
+    local questIDs = {}
+    local numEntries = C_QuestLog.GetNumQuestLogEntries()
+    
+    for i = 1, numEntries do
+        local questInfo = C_QuestLog.GetInfo(i)
+        if questInfo and not questInfo.isHeader then
+            local questID = questInfo.questID
+            if questID then
+                -- Skip hidden quests
+                local questTagInfo = C_QuestLog.GetQuestTagInfo and C_QuestLog.GetQuestTagInfo(questID)
+                if not (questTagInfo and questTagInfo.tagName and questTagInfo.tagName:lower() == "hidden quest") then
+                    table.insert(questIDs, questID)
+                end
+            end
+        end
+    end
+    
+    -- Split into chunks of 10 IDs
+    local chunkSize = 10
+    local totalChunks = math.ceil(#questIDs / chunkSize)
+    
+    for i = 1, totalChunks do
+        local startIdx = (i - 1) * chunkSize + 1
+        local endIdx = math.min(i * chunkSize, #questIDs)
+        local chunkIDs = {}
+        
+        for j = startIdx, endIdx do
+            table.insert(chunkIDs, tostring(questIDs[j]))
+        end
+        
+        local payload = string.format("QUEST_LOG:%d:%d:%s", i, totalChunks, table.concat(chunkIDs, ","))
+        QueueMessage("QUEST_LOG", payload, i, totalChunks)
+    end
+end
+
+-- UI refresh debouncing
+local function QueueDisplayRefresh()
+    pendingDisplayRefresh = true
 end
 
 -- Helper to get party member quest data using C_QuestLog.IsUnitOnQuest
@@ -220,6 +359,76 @@ local function CreateSettingsPanel()
             UIDropDownMenu_SetText(textSizeDropdown, option.text)
             break
         end
+    end
+    
+    -- Recent Activity Lookback Slider
+    local lookbackLabel = settingsPanel:CreateFontString(nil, "ARTWORK", "GameFontNormal")
+    lookbackLabel:SetPoint("TOPLEFT", textSizeDropdown, "BOTTOMLEFT", 15, -24)
+    lookbackLabel:SetText("Recent Activity Lookback (minutes):")
+    
+    local lookbackSlider = CreateFrame("Slider", "QuestCoopLookbackSlider", settingsPanel, "OptionsSliderTemplate")
+    lookbackSlider:SetPoint("TOPLEFT", lookbackLabel, "BOTTOMLEFT", 0, -16)
+    lookbackSlider:SetMinMaxValues(5, 120)
+    lookbackSlider:SetValueStep(5)
+    lookbackSlider:SetObeyStepOnDrag(true)
+    lookbackSlider:SetWidth(200)
+    _G[lookbackSlider:GetName() .. "Low"]:SetText("5")
+    _G[lookbackSlider:GetName() .. "High"]:SetText("120")
+    _G[lookbackSlider:GetName() .. "Text"]:SetText(GetSetting("recentLookbackMinutes") or 10)
+    lookbackSlider:SetValue(GetSetting("recentLookbackMinutes") or 10)
+    
+    lookbackSlider:SetScript("OnValueChanged", function(self, value)
+        value = math.floor(value + 0.5) -- Round to nearest integer
+        _G[self:GetName() .. "Text"]:SetText(value)
+        SetSetting("recentLookbackMinutes", value)
+        RefreshQuestWindowIfVisible()
+    end)
+    
+    local lookbackHelp = settingsPanel:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+    lookbackHelp:SetPoint("TOPLEFT", lookbackSlider, "BOTTOMLEFT", 0, -8)
+    lookbackHelp:SetText("How far back to look for 'Wrapping Up' and 'Kicking Off' quests")
+    lookbackHelp:SetTextColor(0.7, 0.7, 0.7)
+    
+    -- Display Sections Checkboxes
+    local sectionsLabel = settingsPanel:CreateFontString(nil, "ARTWORK", "GameFontNormal")
+    sectionsLabel:SetPoint("TOPLEFT", lookbackHelp, "BOTTOMLEFT", 0, -24)
+    sectionsLabel:SetText("Display Sections:")
+    
+    local checkboxYOffset = -24
+    local checkboxOptions = {
+        {key = "wrappingUp", label = "Wrapping Up (recently turned in by party)"},
+        {key = "kickingOff", label = "Kicking Off (recently accepted by party)"},
+        {key = "sharedQuests", label = "Shared Quests (quests all party members have)"},
+        {key = "myQuests", label = "My Unique Quests"},
+        {key = "partyQuests", label = "Party Unique Quests"},
+    }
+    
+    for i, option in ipairs(checkboxOptions) do
+        local checkbox = CreateFrame("CheckButton", "QuestCoopCheckbox" .. option.key, settingsPanel, "UICheckButtonTemplate")
+        checkbox:SetPoint("TOPLEFT", sectionsLabel, "BOTTOMLEFT", 0, checkboxYOffset)
+        _G[checkbox:GetName() .. "Text"]:SetText(option.label)
+        
+        -- Get current value
+        local visibleSections = GetSetting("visibleSections")
+        if not visibleSections then
+            visibleSections = DEFAULT_SETTINGS.visibleSections
+        end
+        checkbox:SetChecked(visibleSections[option.key] ~= false)
+        
+        checkbox:SetScript("OnClick", function(self)
+            local sections = GetSetting("visibleSections")
+            if not sections then
+                sections = {}
+                for k, v in pairs(DEFAULT_SETTINGS.visibleSections) do
+                    sections[k] = v
+                end
+            end
+            sections[option.key] = self:GetChecked()
+            SetSetting("visibleSections", sections)
+            RefreshQuestWindowIfVisible()
+        end)
+        
+        checkboxYOffset = checkboxYOffset - 28
     end
     
     -- Register with Interface Options
@@ -465,7 +674,15 @@ function PrintQuestIDs(silentRefresh)
         sharedQuestCount = sharedQuestCount + #quests
     end
     
-    if sharedQuestCount > 0 then
+    -- Check if sections are visible from settings (define here so it's available for all sections)
+    local showWrappingUp = GetSetting("visibleSections") and GetSetting("visibleSections").wrappingUp ~= false
+    local showKickingOff = GetSetting("visibleSections") and GetSetting("visibleSections").kickingOff ~= false
+    local showSharedQuests = GetSetting("visibleSections") and GetSetting("visibleSections").sharedQuests ~= false
+    local showMyQuests = GetSetting("visibleSections") and GetSetting("visibleSections").myQuests ~= false
+    local showPartyQuests = GetSetting("visibleSections") and GetSetting("visibleSections").partyQuests ~= false
+    local lookbackMinutes = GetSetting("recentLookbackMinutes") or 10
+    
+    if sharedQuestCount > 0 and showSharedQuests then
         -- Create shared section heading
         local sharedHeading = questScrollChild:CreateFontString(nil, "OVERLAY", fontLarge)
         sharedHeading:SetPoint("TOPLEFT", 0, yOff)
@@ -559,6 +776,158 @@ function PrintQuestIDs(silentRefresh)
         yOff = yOff - 15
     end
     
+    -- Render "Wrapping Up" section (party members' recent turn-ins where local player still has the quest)
+    if showWrappingUp then
+        local wrappingUpQuests = {}
+        local currentTime = time()
+        local cutoffTime = currentTime - (lookbackMinutes * 60)
+        
+        for playerName, state in pairs(partyQuestStates) do
+            if playerName ~= GetFullPlayerName("player") then
+                for _, turnin in ipairs(state.wrappingUp) do
+                    if turnin.timestamp >= cutoffTime then
+                        -- Check if local player still has this quest
+                        if C_QuestLog.IsOnQuest(turnin.questID) then
+                            table.insert(wrappingUpQuests, {
+                                questID = turnin.questID,
+                                playerName = playerName,
+                                timestamp = turnin.timestamp
+                            })
+                        end
+                    end
+                end
+            end
+        end
+        
+        if #wrappingUpQuests > 0 then
+            -- Create section heading
+            local wrappingUpHeading = questScrollChild:CreateFontString(nil, "OVERLAY", fontLarge)
+            wrappingUpHeading:SetPoint("TOPLEFT", 0, yOff)
+            wrappingUpHeading:SetJustifyH("LEFT")
+            wrappingUpHeading:SetTextColor(1, 0.6, 0) -- Orange for wrapping up
+            wrappingUpHeading:SetText(string.format("Wrapping Up (%d quests)", #wrappingUpQuests))
+            table.insert(questScrollChild.lines, wrappingUpHeading)
+            yOff = yOff - PLAYER_HEADING_HEIGHT
+            
+            -- Sort by timestamp (most recent first)
+            table.sort(wrappingUpQuests, function(a, b) return a.timestamp > b.timestamp end)
+            
+            for _, quest in ipairs(wrappingUpQuests) do
+                local questName = GetQuestName(quest.questID)
+                
+                -- ID cell
+                local idFS = questScrollChild:CreateFontString(nil, "OVERLAY", fontSmall)
+                idFS:SetPoint("TOPLEFT", COL_ID_X, yOff)
+                idFS:SetJustifyH("LEFT")
+                idFS:SetText(quest.questID)
+                table.insert(questScrollChild.lines, idFS)
+                
+                -- Title cell with player name
+                local titleFS = questScrollChild:CreateFontString(nil, "OVERLAY", fontNormal)
+                titleFS:SetPoint("TOPLEFT", COL_TITLE_X, yOff)
+                titleFS:SetJustifyH("LEFT")
+                titleFS:SetTextColor(1, 1, 1)
+                titleFS:SetText(questName .. " [" .. ShortName(quest.playerName) .. "]")
+                table.insert(questScrollChild.lines, titleFS)
+                
+                -- Tooltip
+                local rowButton = CreateFrame("Button", nil, questScrollChild)
+                rowButton:SetPoint("TOPLEFT", idFS, "TOPLEFT", -2, 2)
+                rowButton:SetPoint("BOTTOMRIGHT", titleFS, "BOTTOMRIGHT", 2, -2)
+                rowButton:SetScript("OnEnter", function()
+                    GameTooltip:SetOwner(rowButton, "ANCHOR_CURSOR")
+                    GameTooltip:AddLine(questName, 1, 1, 1, true)
+                    GameTooltip:AddLine(string.format("Quest ID: %d", quest.questID), 0.9, 0.9, 0.9)
+                    local minutesAgo = math.floor((currentTime - quest.timestamp) / 60)
+                    GameTooltip:AddLine(ShortName(quest.playerName) .. " turned this in " .. minutesAgo .. " minutes ago", 1, 0.6, 0)
+                    GameTooltip:Show()
+                end)
+                rowButton:SetScript("OnLeave", function() GameTooltip:Hide() end)
+                table.insert(questScrollChild.lines, rowButton)
+                
+                yOff = yOff - ROW_HEIGHT - 2
+            end
+            
+            yOff = yOff - 15
+        end
+    end
+    
+    -- Render "Kicking Off" section (party members' recent accepts where local player doesn't have the quest)
+    if showKickingOff then
+        local kickingOffQuests = {}
+        local currentTime = time()
+        local cutoffTime = currentTime - (lookbackMinutes * 60)
+        
+        for playerName, state in pairs(partyQuestStates) do
+            if playerName ~= GetFullPlayerName("player") then
+                for _, accept in ipairs(state.kickingOff) do
+                    if accept.timestamp >= cutoffTime then
+                        -- Check if local player does NOT have this quest
+                        if not C_QuestLog.IsOnQuest(accept.questID) then
+                            table.insert(kickingOffQuests, {
+                                questID = accept.questID,
+                                playerName = playerName,
+                                timestamp = accept.timestamp
+                            })
+                        end
+                    end
+                end
+            end
+        end
+        
+        if #kickingOffQuests > 0 then
+            -- Create section heading
+            local kickingOffHeading = questScrollChild:CreateFontString(nil, "OVERLAY", fontLarge)
+            kickingOffHeading:SetPoint("TOPLEFT", 0, yOff)
+            kickingOffHeading:SetJustifyH("LEFT")
+            kickingOffHeading:SetTextColor(0, 0.8, 1) -- Cyan for kicking off
+            kickingOffHeading:SetText(string.format("Kicking Off (%d quests)", #kickingOffQuests))
+            table.insert(questScrollChild.lines, kickingOffHeading)
+            yOff = yOff - PLAYER_HEADING_HEIGHT
+            
+            -- Sort by timestamp (most recent first)
+            table.sort(kickingOffQuests, function(a, b) return a.timestamp > b.timestamp end)
+            
+            for _, quest in ipairs(kickingOffQuests) do
+                local questName = GetQuestName(quest.questID)
+                
+                -- ID cell
+                local idFS = questScrollChild:CreateFontString(nil, "OVERLAY", fontSmall)
+                idFS:SetPoint("TOPLEFT", COL_ID_X, yOff)
+                idFS:SetJustifyH("LEFT")
+                idFS:SetText(quest.questID)
+                table.insert(questScrollChild.lines, idFS)
+                
+                -- Title cell with player name
+                local titleFS = questScrollChild:CreateFontString(nil, "OVERLAY", fontNormal)
+                titleFS:SetPoint("TOPLEFT", COL_TITLE_X, yOff)
+                titleFS:SetJustifyH("LEFT")
+                titleFS:SetTextColor(1, 1, 1)
+                titleFS:SetText(questName .. " [" .. ShortName(quest.playerName) .. "]")
+                table.insert(questScrollChild.lines, titleFS)
+                
+                -- Tooltip
+                local rowButton = CreateFrame("Button", nil, questScrollChild)
+                rowButton:SetPoint("TOPLEFT", idFS, "TOPLEFT", -2, 2)
+                rowButton:SetPoint("BOTTOMRIGHT", titleFS, "BOTTOMRIGHT", 2, -2)
+                rowButton:SetScript("OnEnter", function()
+                    GameTooltip:SetOwner(rowButton, "ANCHOR_CURSOR")
+                    GameTooltip:AddLine(questName, 1, 1, 1, true)
+                    GameTooltip:AddLine(string.format("Quest ID: %d", quest.questID), 0.9, 0.9, 0.9)
+                    local minutesAgo = math.floor((currentTime - quest.timestamp) / 60)
+                    GameTooltip:AddLine(ShortName(quest.playerName) .. " picked this up " .. minutesAgo .. " minutes ago", 0, 0.8, 1)
+                    GameTooltip:Show()
+                end)
+                rowButton:SetScript("OnLeave", function() GameTooltip:Hide() end)
+                table.insert(questScrollChild.lines, rowButton)
+                
+                yOff = yOff - ROW_HEIGHT - 2
+            end
+            
+            yOff = yOff - 15
+        end
+    end
+    
     -- Then render individual player quests (excluding shared)
     for _, playerDisplayName in ipairs(sortedPlayers) do
         local questsByTag = questsByPlayer[playerDisplayName]
@@ -571,6 +940,11 @@ function PrintQuestIDs(silentRefresh)
         
         -- Only display players with quests
         if totalQuests > 0 then
+            -- Check visibility settings
+            local isLocalPlayer = (playerDisplayName == UnitName("player"))
+            local shouldShow = (isLocalPlayer and showMyQuests) or (not isLocalPlayer and showPartyQuests)
+            
+            if shouldShow then
             -- Create player name heading
             local playerHeading = questScrollChild:CreateFontString(nil, "OVERLAY", fontLarge)
             playerHeading:SetPoint("TOPLEFT", 0, yOff)
@@ -686,6 +1060,7 @@ function PrintQuestIDs(silentRefresh)
             
             -- Add spacing after each player
             yOff = yOff - 10
+            end -- end if shouldShow
         end -- end if totalQuests > 0
     end -- end for players loop
 
@@ -708,7 +1083,99 @@ frame:SetScript("OnUpdate", function(self, elapsed)
         autoSyncTimer = 0
         AutoSyncQuestTracking()
     end
+    
+    -- Process message queue
+    SendQueuedMessages(elapsed)
+    
+    -- Handle debounced display refresh
+    if pendingDisplayRefresh and (time() - lastDisplayRefreshTime >= DISPLAY_REFRESH_DEBOUNCE) then
+        pendingDisplayRefresh = false
+        lastDisplayRefreshTime = time()
+        RefreshQuestWindowIfVisible()
+    end
 end)
+
+-- Handle incoming addon messages
+local function HandleAddonMessage(prefix, message, channel, sender)
+    if prefix ~= ADDON_PREFIX then return end
+    if channel ~= "PARTY" and channel ~= "RAID" then return end
+    
+    -- Parse message type
+    local msgType, rest = message:match("^([^:]+):(.*)$")
+    if not msgType then return end
+    
+    -- Initialize player state if needed
+    if not partyQuestStates[sender] then
+        partyQuestStates[sender] = {
+            activeQuestIDs = {},
+            wrappingUp = {},
+            kickingOff = {},
+            lastUpdate = time(),
+            inParty = true
+        }
+    end
+    
+    partyQuestStates[sender].lastUpdate = time()
+    partyQuestStates[sender].inParty = true
+    
+    if msgType == "QUEST_ACCEPT" then
+        local questID, timestamp = rest:match("^(%d+):(%d+)$")
+        if questID and timestamp then
+            questID = tonumber(questID)
+            timestamp = tonumber(timestamp)
+            table.insert(partyQuestStates[sender].kickingOff, {questID = questID, timestamp = timestamp})
+            partyQuestStates[sender].activeQuestIDs[questID] = true
+            QueueDisplayRefresh()
+        end
+        
+    elseif msgType == "QUEST_TURNIN" then
+        local questID, timestamp = rest:match("^(%d+):(%d+)$")
+        if questID and timestamp then
+            questID = tonumber(questID)
+            timestamp = tonumber(timestamp)
+            table.insert(partyQuestStates[sender].wrappingUp, {questID = questID, timestamp = timestamp})
+            partyQuestStates[sender].activeQuestIDs[questID] = nil
+            QueueDisplayRefresh()
+        end
+        
+    elseif msgType == "QUEST_LOG" then
+        local chunkIndex, totalChunks, questIDsStr = rest:match("^(%d+):(%d+):(.*)$")
+        if chunkIndex and totalChunks and questIDsStr then
+            chunkIndex = tonumber(chunkIndex)
+            totalChunks = tonumber(totalChunks)
+            
+            -- Initialize chunk buffer
+            if not incomingChunks[sender] then
+                incomingChunks[sender] = {totalChunks = totalChunks, receivedAt = time()}
+            end
+            
+            incomingChunks[sender][chunkIndex] = questIDsStr
+            
+            -- Check if we have all chunks
+            local complete = true
+            for i = 1, totalChunks do
+                if not incomingChunks[sender][i] then
+                    complete = false
+                    break
+                end
+            end
+            
+            if complete then
+                -- Reconstruct full quest list
+                local allQuestIDs = {}
+                for i = 1, totalChunks do
+                    for questID in string.gmatch(incomingChunks[sender][i], "(%d+)") do
+                        allQuestIDs[tonumber(questID)] = true
+                    end
+                end
+                
+                partyQuestStates[sender].activeQuestIDs = allQuestIDs
+                incomingChunks[sender] = nil -- Clear buffer
+                QueueDisplayRefresh()
+            end
+        end
+    end
+end
 
 frame:SetScript("OnEvent", function(self, event, ...)
     if event == "PLAYER_LOGIN" then
@@ -762,12 +1229,146 @@ frame:SetScript("OnEvent", function(self, event, ...)
             printButton:Show()
         end
         
+        -- Initialize quest cache
+        if not QuestCoopDB.questCache then
+            QuestCoopDB.questCache = {}
+        end
+        CleanupQuestCache()
+        
+        -- Register addon message prefix
+        C_ChatInfo.RegisterAddonMessagePrefix(ADDON_PREFIX)
+        
         -- Run initial auto-sync after login
         C_Timer.After(2, AutoSyncQuestTracking)
     end
+    
+    -- Handle addon messages
+    if event == "CHAT_MSG_ADDON" then
+        local prefix, message, channel, sender = ...
+        HandleAddonMessage(prefix, message, channel, sender)
+    end
+    
+    -- Handle quest data load results (for cache population)
+    if event == "QUEST_DATA_LOAD_RESULT" then
+        local questID, success = ...
+        if success then
+            local name = C_QuestLog.GetTitleForQuestID(questID)
+            if name then
+                if not QuestCoopDB.questCache then QuestCoopDB.questCache = {} end
+                QuestCoopDB.questCache[questID] = {name = name, timestamp = time()}
+            end
+        end
+    end
+    
+    -- Handle quest turn-ins
+    if event == "QUEST_TURNED_IN" then
+        local questID = ...
+        if questID then
+            local payload = string.format("QUEST_TURNIN:%d:%d", questID, time())
+            QueueMessage("QUEST_TURNIN", payload)
+            
+            -- Update local state
+            local playerName = GetFullPlayerName("player")
+            if playerName and partyQuestStates[playerName] then
+                table.insert(partyQuestStates[playerName].wrappingUp, {questID = questID, timestamp = time()})
+                partyQuestStates[playerName].activeQuestIDs[questID] = nil
+            end
+            
+            QueueDisplayRefresh()
+        end
+    end
+    
+    -- Handle quest accepts
+    if event == "QUEST_ACCEPTED" then
+        local questID = ...
+        if questID then
+            local payload = string.format("QUEST_ACCEPT:%d:%d", questID, time())
+            QueueMessage("QUEST_ACCEPT", payload)
+            
+            -- Update local state
+            local playerName = GetFullPlayerName("player")
+            if playerName and partyQuestStates[playerName] then
+                table.insert(partyQuestStates[playerName].kickingOff, {questID = questID, timestamp = time()})
+                partyQuestStates[playerName].activeQuestIDs[questID] = true
+            end
+            
+            QueueDisplayRefresh()
+        end
+    end
+    
+    -- Handle roster updates with player tracking
+    if event == "GROUP_ROSTER_UPDATE" then
+        local currentTime = time()
+        local currentMembers = {}
+        
+        -- Build list of current party members
+        if IsInGroup() then
+            for i = 1, GetNumGroupMembers() do
+                local unit = (IsInRaid() and "raid" or "party") .. i
+                local fullName = GetFullPlayerName(unit)
+                if fullName then
+                    currentMembers[fullName] = true
+                end
+            end
+        end
+        
+        -- Add self
+        local selfName = GetFullPlayerName("player")
+        if selfName then
+            currentMembers[selfName] = true
+            
+            -- Initialize self state if needed
+            if not partyQuestStates[selfName] then
+                partyQuestStates[selfName] = {
+                    activeQuestIDs = {},
+                    wrappingUp = {},
+                    kickingOff = {},
+                    lastUpdate = currentTime,
+                    inParty = true
+                }
+            end
+        end
+        
+        -- Update party states
+        for playerName, state in pairs(partyQuestStates) do
+            if currentMembers[playerName] then
+                state.inParty = true
+                state.lastUpdate = currentTime
+            else
+                if state.inParty then
+                    -- Player just left, mark as inactive
+                    state.inParty = false
+                end
+            end
+        end
+        
+        -- Cleanup stale entries
+        for playerName, state in pairs(partyQuestStates) do
+            if not state.inParty and (currentTime - state.lastUpdate > STALE_DATA_RETENTION) then
+                partyQuestStates[playerName] = nil
+            end
+        end
+        
+        -- Broadcast quest log with jitter (skip if we just synced recently)
+        if IsInGroup() and selfName then
+            local state = partyQuestStates[selfName]
+            if not state.lastBroadcast or (currentTime - state.lastBroadcast > 30) then
+                local jitter = math.random(0, 5000) / 1000
+                C_Timer.After(jitter, function()
+                    BroadcastQuestLog()
+                    if partyQuestStates[selfName] then
+                        partyQuestStates[selfName].lastBroadcast = time()
+                    end
+                end)
+            end
+        end
+        
+        QueueDisplayRefresh()
+    end
+    
     -- Auto-refresh triggers
-    if event == "QUEST_ACCEPTED" or event == "QUEST_REMOVED" or event == "QUEST_WATCH_LIST_CHANGED" or event == "QUEST_LOG_UPDATE" or event == "GROUP_ROSTER_UPDATE" then
-        RefreshQuestWindowIfVisible()
+    if event == "QUEST_REMOVED" or event == "QUEST_WATCH_LIST_CHANGED" or event == "QUEST_LOG_UPDATE" then
+        QueueDisplayRefresh()
         -- Also trigger auto-sync on these events
         AutoSyncQuestTracking()
     end
@@ -796,3 +1397,6 @@ frame:RegisterEvent("QUEST_WATCH_LIST_CHANGED")
 frame:RegisterEvent("QUEST_LOG_UPDATE")
 frame:RegisterEvent("GROUP_ROSTER_UPDATE")
 frame:RegisterEvent("CHAT_MSG_SYSTEM")
+frame:RegisterEvent("CHAT_MSG_ADDON")
+frame:RegisterEvent("QUEST_TURNED_IN")
+frame:RegisterEvent("QUEST_DATA_LOAD_RESULT")


### PR DESCRIPTION
- Implement addon message protocol for syncing quest states between party members
- Add QUEST_LOG chunking (10 IDs per message, 1s cooldown, 255-byte limit compliance)
- Implement quest name cache with 30-day expiration in SavedVariables
- Add party member tracking with 5-minute DC grace period
- Create 'Wrapping Up' section showing recently turned-in quests by party
- Create 'Kicking Off' section showing recently accepted quests by party
- Add UI refresh debouncing (100ms) to prevent flicker during message bursts
- Extend settings panel with lookback time slider (5-120 min, default 10)
- Add visibility toggles for all 5 quest sections
- Implement random sync jitter (0-5s) to prevent party-wide sync storms
- Handle QUEST_TURNED_IN, QUEST_ACCEPTED, CHAT_MSG_ADDON events
- Update GROUP_ROSTER_UPDATE with player state tracking and cleanup

Technical improvements:
- Global message queue with throttling
- Full PlayerName-Realm identification for cross-realm support
- Stale data cleanup after 5-minute retention window
- Message payload safety checks (<250 bytes)
- Async quest name loading with QUEST_DATA_LOAD_RESULT