### PR TITLE
fix: switch to BigWigs Packager for CurseForge deployment

### DIFF
--- a/.github/workflows/deploy-curseforge.yml
+++ b/.github/workflows/deploy-curseforge.yml
@@ -1,32 +1,19 @@
-name: Deploy to CurseForge
+name: Release
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - '*'
 
 jobs:
-  deploy:
+  release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Package Addon
-        run: |
-          mkdir -p release/QuestCoop
-          cp -r QuestCoop.toc src/ LICENSE README.md release/QuestCoop/
-          cd release
-          zip -r QuestCoop.zip QuestCoop/
-
-      - name: Upload to CurseForge
-        uses: itsmeow/curseforge-upload@v3
+      - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.CURSEFORGE_SECRET }}
-          project_id: "1386288"
-          game_endpoint: wow
-          file_path: release/QuestCoop.zip
-          release_type: release
-          changelog: "See https://github.com/${{ github.repository }}/commits/main"
-          changelog_type: markdown
-          game_versions: "Retail"
+          fetch-depth: 0
+
+      - uses: BigWigsMods/packager@v2
+        env:
+          CF_API_KEY: ${{ secrets.CURSEFORGE_SECRET }}
+          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -1,0 +1,7 @@
+package-as: QuestCoop
+
+ignore:
+  - .github
+  - .vscode
+  - screenshot.png
+  - README.md

--- a/QuestCoop.toc
+++ b/QuestCoop.toc
@@ -1,7 +1,9 @@
 ## Interface: 120001
 ## Title: Quest Coop
 ## Notes: Hides all quests from the quest tracker
-## Author: YourName
+## Author: Tobie Tusing
+## Version: @project-version@
+## X-Curse-Project-ID: 1386288
 ## SavedVariables: QuestCoopDB
 
 

--- a/QuestCoop.toc
+++ b/QuestCoop.toc
@@ -1,7 +1,7 @@
 ## Interface: 120001
 ## Title: Quest Coop
 ## Notes: Hides all quests from the quest tracker
-## Author: Tobie Tusing
+## Author: heartbourne
 ## Version: @project-version@
 ## X-Curse-Project-ID: 1386288
 ## SavedVariables: QuestCoopDB


### PR DESCRIPTION
The previous workflow used game_versions: "Retail" which CurseForge's API doesn't recognize — files were uploaded without game version tags, so the CurseForge client served an older manually-tagged file instead.

BigWigsMods/packager reads the ## Interface number from the TOC and resolves the correct CurseForge game version IDs automatically. It also replaces @project-version@ in the TOC with the git tag at release time.

Workflow now triggers on version tags (e.g. v1.2.3) rather than every push to main — create a tag to publish a release.

Also adds .pkgmeta to control which files are bundled, fixes Author field in the TOC, and adds Version/@project-version@ and X-Curse-Project-ID metadata.