### PR TITLE
feat: QC categories, smart tracking, QC Alerts, multi-state track modes

### DIFF
--- a/src/QuestCoop.lua
+++ b/src/QuestCoop.lua
@@ -5,6 +5,23 @@ local DEFAULT_SETTINGS = {
     textSize = "medium", -- small, medium, large
     alwaysLeader = false,
     showWorldQuestsInRecent = false,
+    maxQuestsToTrack = 5,
+}
+
+-- QC categories that are hidden from the window entirely
+local HIDDEN_CATEGORIES = {
+    ["Emissary Quest"] = true,
+    ["Island Weekly Quest"] = true,
+    ["Hidden"] = true,
+}
+
+-- Tracking mode cycling and display
+local TRACK_MODE_CYCLE   = {auto = "always", always = "never", never = "auto"}
+local TRACK_MODE_LABELS  = {auto = "Auto", always = "Always", never = "Never"}
+local TRACK_MODE_COLORS  = {
+    auto   = {0.7, 0.7, 0.7},
+    always = {0.3, 1.0, 0.3},
+    never  = {1.0, 0.4, 0.4},
 }
 
 local function ShortName(name)
@@ -12,7 +29,6 @@ local function ShortName(name)
     return name:match("^[^%-]+") or name
 end
 
--- Settings management
 local function GetSetting(key)
     if not QuestCoopDB then QuestCoopDB = {} end
     if not QuestCoopDB.settings then QuestCoopDB.settings = {} end
@@ -39,46 +55,63 @@ local function GetFontSize()
     end
 end
 
--- Table to track which party members have "Always be QuestCoop Leader" enabled.
--- Populated via addon messages; keyed by short character name.
+-- Determine the QC category for a quest. Prefers WoW tag, falls back to campaign/zone/general.
+local function GetQuestCategory(questInfo, questTagInfo)
+    if questTagInfo and questTagInfo.tagName and questTagInfo.tagName ~= "" then
+        if HIDDEN_CATEGORIES[questTagInfo.tagName] then
+            return "Hidden"
+        end
+        return questTagInfo.tagName
+    end
+    if questInfo.campaignID then
+        return "Campaign"
+    end
+    if questInfo.zoneOrSort and questInfo.zoneOrSort ~= "" then
+        return questInfo.zoneOrSort
+    end
+    return "General"
+end
+
+-- Party / leader management
 local leaderPrefs = {}
+local receivedTrackingModes = {} -- runtime only, from QuestCoop leader
+local receivedMaxTrack = nil     -- runtime only, from QuestCoop leader
 
--- Untracked quests received from the QuestCoop leader (runtime only, not saved).
-local receivedUntrackedQuests = {}
+-- Quest activity timestamps for smart tracking
+local questLastActivity = {} -- [questID] = GetTime()
 
--- Recently completed quests shown in the recently completed window: {[questID] = {title, completors={}, completorSet={}}}
-local recentlyCompletedQuests = {}
--- Quests waiting for the 10-second grace period before appearing in the window.
+-- QC Alerts data
+local recentlyCompletedQuests = {}  -- [questID] = {title, completors, completorSet}
 local pendingCompletedQuests = {}
--- Quests the local player has turned in this session, used to suppress redundant entries.
 local selfCompletedQuests = {}
+local notSharedAlerts = {}          -- [questID] = {title, detectedTime}
 
--- Broadcast our "always leader" preference to the party.
+-- Forward declarations
+local RefreshQuestWindowIfVisible
+local ToggleQCAlertsWindow
+local ShowQCAlerts
+local RefreshQCAlertsWindow
+local RemoveQuestFromRecentlyCompleted
+
 local function BroadcastLeaderPref()
     if not IsInGroup() then return end
     local val = GetSetting("alwaysLeader") and "1" or "0"
     C_ChatInfo.SendAddonMessage("QuestCoop", "LEADER_PREF|" .. val, "PARTY")
 end
 
--- Remove leaderPrefs entries for players no longer in the party.
 local function CleanupLeaderPrefs()
     local currentMembers = {}
     currentMembers[ShortName(UnitName("player"))] = true
     for i = 1, GetNumGroupMembers() do
         local unit = (IsInRaid() and "raid" or "party") .. i
         local name = UnitName(unit)
-        if name then
-            currentMembers[ShortName(name)] = true
-        end
+        if name then currentMembers[ShortName(name)] = true end
     end
     for name in pairs(leaderPrefs) do
-        if not currentMembers[name] then
-            leaderPrefs[name] = nil
-        end
+        if not currentMembers[name] then leaderPrefs[name] = nil end
     end
 end
 
--- Returns the short name of the current WoW party leader (or the player if solo).
 local function GetWoWPartyLeaderName()
     local units = {"player"}
     for i = 1, GetNumGroupMembers() do
@@ -92,70 +125,69 @@ local function GetWoWPartyLeaderName()
     return ShortName(UnitName("player"))
 end
 
--- Returns the short name of the QuestCoop leader.
--- If any party member has "Always be QuestCoop Leader" checked, the
--- alphabetically earliest name among them wins. Otherwise falls back
--- to the WoW party leader.
 local function GetQuestCoopLeader()
-    -- Always seed our own current preference so it's up to date.
     local selfName = ShortName(UnitName("player"))
     leaderPrefs[selfName] = GetSetting("alwaysLeader")
-
     local candidates = {}
     for name, wantsLeader in pairs(leaderPrefs) do
-        if wantsLeader then
-            table.insert(candidates, name)
-        end
+        if wantsLeader then table.insert(candidates, name) end
     end
-
-    if #candidates == 0 then
-        return GetWoWPartyLeaderName()
-    end
-
+    if #candidates == 0 then return GetWoWPartyLeaderName() end
     table.sort(candidates)
     return candidates[1]
 end
 
--- Returns the effective set of untracked quest IDs (leader's own or received from leader).
-local function GetEffectiveUntrackedQuests()
+-- Tracking mode management
+local function GetTrackingModeStore()
     if not QuestCoopDB then QuestCoopDB = {} end
-    if not QuestCoopDB.untrackedQuests then QuestCoopDB.untrackedQuests = {} end
+    if not QuestCoopDB.questTrackingMode then QuestCoopDB.questTrackingMode = {} end
+    return QuestCoopDB.questTrackingMode
+end
+
+-- Returns nil (auto), "always", or "never"
+local function GetEffectiveTrackingMode(questID)
     local selfName = ShortName(UnitName("player"))
     if GetQuestCoopLeader() == selfName then
-        return QuestCoopDB.untrackedQuests
+        return GetTrackingModeStore()[questID]
     else
-        return receivedUntrackedQuests
+        return receivedTrackingModes[questID]
     end
 end
 
--- Broadcast the leader's untracked quest list to the party.
-local function BroadcastUntrackedQuests()
+local function GetEffectiveMaxTrack()
+    local selfName = ShortName(UnitName("player"))
+    if GetQuestCoopLeader() == selfName then
+        return GetSetting("maxQuestsToTrack")
+    else
+        return receivedMaxTrack or GetSetting("maxQuestsToTrack")
+    end
+end
+
+local function BroadcastTrackingModes()
     if not IsInGroup() then return end
     local selfName = ShortName(UnitName("player"))
     if GetQuestCoopLeader() ~= selfName then return end
-    if not QuestCoopDB then QuestCoopDB = {} end
-    if not QuestCoopDB.untrackedQuests then QuestCoopDB.untrackedQuests = {} end
-    local ids = {}
-    for questID in pairs(QuestCoopDB.untrackedQuests) do
-        table.insert(ids, tostring(questID))
+    local store = GetTrackingModeStore()
+    local parts = {}
+    for questID, mode in pairs(store) do
+        table.insert(parts, tostring(questID) .. ":" .. mode)
     end
-    C_ChatInfo.SendAddonMessage("QuestCoop", "UNTRACKED_QUESTS|" .. table.concat(ids, ","), "PARTY")
+    C_ChatInfo.SendAddonMessage("QuestCoop", "TRACK_MODES|" .. table.concat(parts, ","), "PARTY")
 end
 
--- Toggle the untracked state of a quest (leader only). Broadcasts change to party.
-local function SetQuestUntracked(questID, untracked)
-    if not QuestCoopDB then QuestCoopDB = {} end
-    if not QuestCoopDB.untrackedQuests then QuestCoopDB.untrackedQuests = {} end
-    if untracked then
-        QuestCoopDB.untrackedQuests[questID] = true
-        if C_QuestLog.RemoveQuestWatch then C_QuestLog.RemoveQuestWatch(questID) end
-    else
-        QuestCoopDB.untrackedQuests[questID] = nil
-    end
-    BroadcastUntrackedQuests()
+local function BroadcastMaxTrack()
+    if not IsInGroup() then return end
+    local selfName = ShortName(UnitName("player"))
+    if GetQuestCoopLeader() ~= selfName then return end
+    C_ChatInfo.SendAddonMessage("QuestCoop", "MAX_TRACK|" .. tostring(GetSetting("maxQuestsToTrack")), "PARTY")
 end
 
--- Broadcast completion of a quest to party members.
+local function SetQuestTrackingMode(questID, mode)
+    -- mode: nil = auto, "always", "never"
+    GetTrackingModeStore()[questID] = mode
+    BroadcastTrackingModes()
+end
+
 local function BroadcastQuestCompleted(questID)
     if not IsInGroup() then return end
     if not GetSetting("showWorldQuestsInRecent") and C_QuestLog.IsWorldQuest and C_QuestLog.IsWorldQuest(questID) then return end
@@ -163,124 +195,122 @@ local function BroadcastQuestCompleted(questID)
     C_ChatInfo.SendAddonMessage("QuestCoop", string.format("QUEST_COMPLETED|%d|%s", questID, title or ""), "PARTY")
 end
 
--- Helper to get party member quest data using C_QuestLog.IsUnitOnQuest
 local function GetPartyMemberQuestData(unit, questID)
     if not C_QuestLog.IsUnitOnQuest then return nil end
-    
     local isOnQuest = C_QuestLog.IsUnitOnQuest(unit, questID)
     if not isOnQuest then return nil end
-    
-    -- They have the quest, but we can't reliably determine tracking or ready state for other players
-    -- We'll just mark that they have it
     return {has = true}
 end
 
--- Auto-sync quest tracking based on party members
+-- Smart quest tracking: selects up to maxQuestsToTrack quests, prioritizing
+-- always-track, campaign, recent activity, and current zone.
 local function AutoSyncQuestTracking()
-    if not IsInGroup() then return end
-    
+    local currentTime = GetTime()
+    local maxTrack = GetEffectiveMaxTrack()
+    local currentZone = GetZoneText() or ""
+
     local numEntries = C_QuestLog.GetNumQuestLogEntries()
-    local playerName = UnitName("player")
-    
-    -- Build list of all party members including self
-    local allPartyMembers = {playerName}
-    for i = 1, GetNumGroupMembers() do
-        local unit = (IsInRaid() and "raid" or "party") .. i
-        local memberName = UnitName(unit)
-        if memberName and ShortName(memberName) ~= ShortName(playerName) then
-            table.insert(allPartyMembers, unit)
-        end
-    end
-    
-    local partySize = #allPartyMembers
-    if partySize <= 1 then return end -- No one to sync with
-    
-    -- Check each quest in our log
+    local alwaysQuests = {}
+    local autoQuests = {}
+
     for i = 1, numEntries do
         local questInfo = C_QuestLog.GetInfo(i)
         if questInfo and not questInfo.isHeader then
             local questID = questInfo.questID
             if questID then
-                -- Check if ALL party members have this quest
+                local questTagInfo = C_QuestLog.GetQuestTagInfo and C_QuestLog.GetQuestTagInfo(questID)
+                local category = GetQuestCategory(questInfo, questTagInfo)
+                if category ~= "Hidden" then
+                    local mode = GetEffectiveTrackingMode(questID)
+                    if mode == "always" then
+                        table.insert(alwaysQuests, {id = questID, category = category})
+                    elseif mode ~= "never" then
+                        local score = 0
+                        if questInfo.campaignID then score = score + 3 end
+                        local lastActivity = questLastActivity[questID]
+                        if lastActivity and (currentTime - lastActivity) < 600 then
+                            score = score + 2
+                        end
+                        if category == currentZone or (questInfo.zoneOrSort and questInfo.zoneOrSort == currentZone) then
+                            score = score + 1
+                        end
+                        table.insert(autoQuests, {id = questID, score = score})
+                    end
+                end
+            end
+        end
+    end
+
+    table.sort(autoQuests, function(a, b) return a.score > b.score end)
+
+    local toTrack = {}
+    for _, q in ipairs(alwaysQuests) do
+        toTrack[q.id] = true
+    end
+    local remaining = math.max(0, maxTrack - #alwaysQuests)
+    for i = 1, remaining do
+        if autoQuests[i] then toTrack[autoQuests[i].id] = true end
+    end
+
+    -- Apply tracking state
+    for i = 1, numEntries do
+        local questInfo = C_QuestLog.GetInfo(i)
+        if questInfo and not questInfo.isHeader then
+            local questID = questInfo.questID
+            if questID then
+                local isTracked = C_QuestLog.GetQuestWatchType and C_QuestLog.GetQuestWatchType(questID) ~= nil
+                if toTrack[questID] and not isTracked then
+                    if C_QuestLog.AddQuestWatch then C_QuestLog.AddQuestWatch(questID) end
+                elseif not toTrack[questID] and isTracked then
+                    if C_QuestLog.RemoveQuestWatch then C_QuestLog.RemoveQuestWatch(questID) end
+                end
+            end
+        end
+    end
+
+    -- Alert for always-track quests not shared by the whole party
+    if IsInGroup() then
+        for _, q in ipairs(alwaysQuests) do
+            local questID = q.id
+            if not notSharedAlerts[questID] then
                 local sharedByAll = true
-                for j = 2, partySize do -- Skip index 1 (ourselves)
-                    local unit = allPartyMembers[j]
+                for i = 1, GetNumGroupMembers() do
+                    local unit = (IsInRaid() and "raid" or "party") .. i
                     local questData = GetPartyMemberQuestData(unit, questID)
                     if not questData or not questData.has then
                         sharedByAll = false
                         break
                     end
                 end
-                
-                -- Check current tracking state
-                local isTracked = false
-                if C_QuestLog.GetQuestWatchType then
-                    isTracked = C_QuestLog.GetQuestWatchType(questID) ~= nil
-                end
-                
-                -- Respect untracked list: if marked untracked, never auto-track it.
-                local untrackedSet = GetEffectiveUntrackedQuests()
-                if untrackedSet[questID] then
-                    if isTracked and C_QuestLog.RemoveQuestWatch then
-                        C_QuestLog.RemoveQuestWatch(questID)
-                    end
-                elseif sharedByAll and not isTracked then
-                    if C_QuestLog.AddQuestWatch then
-                        C_QuestLog.AddQuestWatch(questID)
-                    end
-                elseif not sharedByAll and isTracked then
-                    if C_QuestLog.RemoveQuestWatch then
-                        C_QuestLog.RemoveQuestWatch(questID)
-                    end
+                if not sharedByAll then
+                    local title = (C_QuestLog.GetTitleForQuestID and C_QuestLog.GetTitleForQuestID(questID)) or ("Quest " .. questID)
+                    notSharedAlerts[questID] = {title = title, detectedTime = currentTime}
+                    ShowQCAlerts()
                 end
             end
         end
     end
 end
 
--- Generic helper to make a frame draggable
-local function MakeDraggable(frame, key)
-    if not frame then return end
-    frame:SetMovable(true)
-    frame:EnableMouse(true)
-    frame:RegisterForDrag("LeftButton")
-    frame:SetClampedToScreen(true)
-    frame:SetScript("OnDragStart", function(self)
-        self:StartMoving()
-    end)
-    frame:SetScript("OnDragStop", function(self)
-        self:StopMovingOrSizing()
-        if not QuestCoopDB then QuestCoopDB = {} end
-        if key then
-            local point, relativeTo, relativePoint, xOfs, yOfs = self:GetPoint()
-            QuestCoopDB[key] = {point = point, relativePoint = relativePoint, x = xOfs, y = yOfs}
-        end
-    end)
-end
-
--- Forward declarations for functions defined later in the file
-local RefreshQuestWindowIfVisible
-local ToggleRecentlyCompletedWindow
-
--- Quest ID window (created lazily)
+-- Forward declarations for quest window
 local questWindow, questScrollFrame, questScrollChild, questLeaderLabel
 local function CreateQuestWindow()
     if questWindow then return end
     questWindow = CreateFrame("Frame", "QuestCoopQuestWindow", UIParent, "BackdropTemplate")
 
-    local savedW = QuestCoopDB and QuestCoopDB.questWindowWidth or 400
+    local savedW = QuestCoopDB and QuestCoopDB.questWindowWidth or 440
     local savedH = QuestCoopDB and QuestCoopDB.questWindowHeight or 300
     questWindow:SetSize(savedW, savedH)
     questWindow:SetPoint("CENTER")
     questWindow:SetMovable(true)
     questWindow:SetResizable(true)
-    questWindow:SetResizeBounds(280, 200)
+    questWindow:SetResizeBounds(320, 200)
     questWindow:EnableMouse(true)
     questWindow:RegisterForDrag("LeftButton")
     questWindow:SetScript("OnDragStart", function(self) self:StartMoving() end)
     questWindow:SetScript("OnDragStop", function(self) self:StopMovingOrSizing() end)
-    questWindow:SetBackdrop({bgFile = "Interface/Tooltips/UI-Tooltip-Background", edgeFile = "Interface/Tooltips/UI-Tooltip-Border", tile = true, tileSize = 16, edgeSize = 16, insets = { left = 4, right = 4, top = 4, bottom = 4 }})
-    questWindow:SetBackdropColor(0,0,0,0.85)
+    questWindow:SetBackdrop({bgFile = "Interface/Tooltips/UI-Tooltip-Background", edgeFile = "Interface/Tooltips/UI-Tooltip-Border", tile = true, tileSize = 16, edgeSize = 16, insets = {left = 4, right = 4, top = 4, bottom = 4}})
+    questWindow:SetBackdropColor(0, 0, 0, 0.85)
     questWindow:Hide()
 
     local title = questWindow:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
@@ -295,22 +325,21 @@ local function CreateQuestWindow()
     local close = CreateFrame("Button", nil, questWindow, "UIPanelCloseButton")
     close:SetPoint("TOPRIGHT", 0, 0)
 
-    local rcBtn = CreateFrame("Button", nil, questWindow, "UIPanelButtonTemplate")
-    rcBtn:SetSize(170, 20)
-    rcBtn:SetPoint("TOP", questLeaderLabel, "BOTTOM", 0, -4)
-    rcBtn:SetText("Recently Completed")
-    rcBtn:SetScript("OnClick", function() ToggleRecentlyCompletedWindow() end)
+    local alertBtn = CreateFrame("Button", nil, questWindow, "UIPanelButtonTemplate")
+    alertBtn:SetSize(120, 20)
+    alertBtn:SetPoint("TOP", questLeaderLabel, "BOTTOM", 0, -4)
+    alertBtn:SetText("QC Alerts")
+    alertBtn:SetScript("OnClick", function() ToggleQCAlertsWindow() end)
 
     questScrollFrame = CreateFrame("ScrollFrame", "QuestCoopQuestScroll", questWindow, "UIPanelScrollFrameTemplate")
     questScrollFrame:SetPoint("TOPLEFT", 16, -82)
     questScrollFrame:SetPoint("BOTTOMRIGHT", -30, 16)
 
     questScrollChild = CreateFrame("Frame", nil, questScrollFrame)
-    questScrollChild:SetSize(360, 1)
+    questScrollChild:SetSize(400, 1)
     questScrollFrame:SetScrollChild(questScrollChild)
     questScrollChild.lines = {}
 
-    -- Resize handle in the bottom-right corner
     local resizeHandle = CreateFrame("Button", nil, questWindow)
     resizeHandle:SetSize(16, 16)
     resizeHandle:SetPoint("BOTTOMRIGHT", -4, 4)
@@ -331,53 +360,50 @@ end
 local settingsPanel
 local function CreateSettingsPanel()
     if settingsPanel then return settingsPanel end
-    
+
     settingsPanel = CreateFrame("Frame", "QuestCoopSettingsPanel", UIParent)
     settingsPanel.name = "QuestCoop"
-    
+
     local title = settingsPanel:CreateFontString(nil, "ARTWORK", "GameFontNormalLarge")
     title:SetPoint("TOPLEFT", 16, -16)
     title:SetText("QuestCoop Settings")
-    
+
     local subtitle = settingsPanel:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
     subtitle:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -8)
     subtitle:SetText("Configure quest display and synchronization options")
-    
-    -- Text Size Section
+
+    -- Text Size
     local textSizeLabel = settingsPanel:CreateFontString(nil, "ARTWORK", "GameFontNormal")
     textSizeLabel:SetPoint("TOPLEFT", subtitle, "BOTTOMLEFT", 0, -24)
     textSizeLabel:SetText("Text Size:")
-    
+
     local textSizeDropdown = CreateFrame("Frame", "QuestCoopTextSizeDropdown", settingsPanel, "UIDropDownMenuTemplate")
     textSizeDropdown:SetPoint("TOPLEFT", textSizeLabel, "BOTTOMLEFT", -15, -8)
-    
+
     local textSizeOptions = {
-        {text = "Small", value = "small"},
+        {text = "Small",  value = "small"},
         {text = "Medium", value = "medium"},
-        {text = "Large", value = "large"},
+        {text = "Large",  value = "large"},
     }
-    
+
     local function TextSizeDropdown_OnClick(self)
         SetSetting("textSize", self.value)
         UIDropDownMenu_SetText(textSizeDropdown, self:GetText())
         RefreshQuestWindowIfVisible()
     end
-    
-    local function TextSizeDropdown_Initialize(self, level)
+
+    UIDropDownMenu_Initialize(textSizeDropdown, function(self, level)
         local info = UIDropDownMenu_CreateInfo()
         for _, option in ipairs(textSizeOptions) do
-            info.text = option.text
-            info.value = option.value
-            info.func = TextSizeDropdown_OnClick
+            info.text    = option.text
+            info.value   = option.value
+            info.func    = TextSizeDropdown_OnClick
             info.checked = (GetSetting("textSize") == option.value)
             UIDropDownMenu_AddButton(info)
         end
-    end
-    
-    UIDropDownMenu_Initialize(textSizeDropdown, TextSizeDropdown_Initialize)
+    end)
     UIDropDownMenu_SetWidth(textSizeDropdown, 120)
-    
-    -- Set initial text
+
     local currentSize = GetSetting("textSize")
     for _, option in ipairs(textSizeOptions) do
         if option.value == currentSize then
@@ -386,7 +412,7 @@ local function CreateSettingsPanel()
         end
     end
 
-    -- Always Leader Section
+    -- Always Leader
     local alwaysLeaderCheckbox = CreateFrame("CheckButton", "QuestCoopAlwaysLeaderCheckbox", settingsPanel, "UICheckButtonTemplate")
     alwaysLeaderCheckbox:SetPoint("TOPLEFT", textSizeDropdown, "BOTTOMLEFT", 15, -16)
     alwaysLeaderCheckbox:SetChecked(GetSetting("alwaysLeader"))
@@ -404,9 +430,41 @@ local function CreateSettingsPanel()
     alwaysLeaderDesc:SetPoint("TOPLEFT", alwaysLeaderCheckbox, "BOTTOMLEFT", 4, -4)
     alwaysLeaderDesc:SetText("If multiple party members have this checked, the alphabetically earliest name leads. Overrides the WoW party leader.")
 
-    -- World Quests in Recently Completed Section
+    -- Max Quests to Track
+    local maxTrackLabel = settingsPanel:CreateFontString(nil, "ARTWORK", "GameFontNormal")
+    maxTrackLabel:SetPoint("TOPLEFT", alwaysLeaderDesc, "BOTTOMLEFT", -4, -20)
+    maxTrackLabel:SetText("Max Quests to Track:")
+
+    local maxTrackSlider = CreateFrame("Slider", "QuestCoopMaxTrackSlider", settingsPanel, "OptionsSliderTemplate")
+    maxTrackSlider:SetPoint("TOPLEFT", maxTrackLabel, "BOTTOMLEFT", 0, -14)
+    maxTrackSlider:SetMinMaxValues(1, 20)
+    maxTrackSlider:SetValueStep(1)
+    maxTrackSlider:SetValue(GetSetting("maxQuestsToTrack"))
+    maxTrackSlider:SetWidth(200)
+    if maxTrackSlider.SetObeyStepOnDrag then maxTrackSlider:SetObeyStepOnDrag(true) end
+    _G[maxTrackSlider:GetName() .. "Low"]:SetText("1")
+    _G[maxTrackSlider:GetName() .. "High"]:SetText("20")
+    _G[maxTrackSlider:GetName() .. "Text"]:SetText("")
+
+    local maxTrackValueLabel = settingsPanel:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+    maxTrackValueLabel:SetPoint("LEFT", maxTrackSlider, "RIGHT", 10, 0)
+    maxTrackValueLabel:SetText(tostring(GetSetting("maxQuestsToTrack")))
+
+    maxTrackSlider:SetScript("OnValueChanged", function(self, value)
+        value = math.floor(value + 0.5)
+        SetSetting("maxQuestsToTrack", value)
+        maxTrackValueLabel:SetText(tostring(value))
+        BroadcastMaxTrack()
+        AutoSyncQuestTracking()
+    end)
+
+    local maxTrackDesc = settingsPanel:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+    maxTrackDesc:SetPoint("TOPLEFT", maxTrackSlider, "BOTTOMLEFT", 0, -10)
+    maxTrackDesc:SetText("Max tracked quests. 'Always' mode quests count toward this limit first. Leader's value syncs to party.")
+
+    -- World Quests in QC Alerts
     local worldQuestCheckbox = CreateFrame("CheckButton", "QuestCoopWorldQuestCheckbox", settingsPanel, "UICheckButtonTemplate")
-    worldQuestCheckbox:SetPoint("TOPLEFT", alwaysLeaderDesc, "BOTTOMLEFT", -4, -16)
+    worldQuestCheckbox:SetPoint("TOPLEFT", maxTrackDesc, "BOTTOMLEFT", -4, -16)
     worldQuestCheckbox:SetChecked(GetSetting("showWorldQuestsInRecent"))
     worldQuestCheckbox:SetScript("OnClick", function(self)
         SetSetting("showWorldQuestsInRecent", self:GetChecked())
@@ -414,126 +472,99 @@ local function CreateSettingsPanel()
 
     local worldQuestLabel = settingsPanel:CreateFontString(nil, "ARTWORK", "GameFontNormal")
     worldQuestLabel:SetPoint("LEFT", worldQuestCheckbox, "RIGHT", 2, 0)
-    worldQuestLabel:SetText("Show World Quests in Recently Completed")
+    worldQuestLabel:SetText("Show World Quests in QC Alerts")
 
-    -- Register with Interface Options
     if InterfaceOptions_AddCategory then
         InterfaceOptions_AddCategory(settingsPanel)
     elseif Settings and Settings.RegisterCanvasLayoutCategory then
         local category = Settings.RegisterCanvasLayoutCategory(settingsPanel, settingsPanel.name)
         Settings.RegisterAddOnCategory(category)
     end
-    
+
     return settingsPanel
 end
 
--- Internal helper to refresh quest window if shown (silent)
 RefreshQuestWindowIfVisible = function()
     if not questWindow or not questWindow:IsShown() then return end
-    -- Call PrintQuestIDs but without shift printing and without forcing visibility changes beyond refresh.
-    PrintQuestIDs(true) -- pass silent flag
+    PrintQuestIDs(true)
 end
 
--- Function to print current quest IDs
--- PrintQuestIDs(silentRefresh)
--- When silentRefresh is true, we don't echo to chat even if shift is down.
+-- Main quest window rendering
 function PrintQuestIDs(silentRefresh)
     CreateQuestWindow()
     if questLeaderLabel then
         questLeaderLabel:SetText("QuestCoop Leader: " .. GetQuestCoopLeader())
     end
-    -- Build structured rows organized by player and tag
-    -- questsByPlayer[playerName][tagName] = {quest1, quest2, ...}
-    local questsByPlayer = {}
+
     local playerName = UnitName("player")
+    local questsByPlayer = {}
     questsByPlayer[playerName] = {}
-    
-    -- First, collect local player's quests
+
     local numEntries = C_QuestLog.GetNumQuestLogEntries()
     local shiftDown = IsShiftKeyDown and IsShiftKeyDown() and not silentRefresh
+
+    -- Collect local player's quests
     for i = 1, numEntries do
         local questInfo = C_QuestLog.GetInfo(i)
         if questInfo and not questInfo.isHeader then
             local questID = questInfo.questID
             if questID then
                 local title = questInfo.title or "(no title)"
-                -- Determine tracked state. Retail API first, legacy fallback.
-                local tracked = false
-                if C_QuestLog.GetQuestWatchType then
-                    tracked = C_QuestLog.GetQuestWatchType(questID) ~= nil
-                elseif IsQuestWatched then
-                    local logIndex = C_QuestLog.GetLogIndexForQuestID and C_QuestLog.GetLogIndexForQuestID(questID)
-                    if logIndex then
-                        tracked = IsQuestWatched(logIndex)
-                    end
-                end
-                local trackText = tracked and "Yes" or "No"
-                -- Determine readiness for turn-in (completion of objectives)
-                local ready = false
-                if C_QuestLog.IsComplete then
-                    ready = C_QuestLog.IsComplete(questID)
-                elseif IsQuestComplete then
-                    ready = IsQuestComplete(questID)
-                elseif questInfo.isComplete ~= nil then
-                    ready = questInfo.isComplete
-                end
-                local readyText = ready and "Yes" or "No"
                 local questTagInfo = C_QuestLog.GetQuestTagInfo and C_QuestLog.GetQuestTagInfo(questID)
-                -- Skip quests with "hidden quest" tag
-                if questTagInfo and questTagInfo.tagName and questTagInfo.tagName:lower() == "hidden quest" then
-                    -- Skip hidden quests
-                else
-                    local zoneOrSort = questInfo.campaignID and ("Campaign") or (questInfo.zoneOrSort or "")
-                    local detailedCategory = questInfo.header and questInfo.header or zoneOrSort
-                    local tagName = questTagInfo and questTagInfo.tagName or "No Tag"
-                    
-                    -- Initialize tag group if needed
-                    if not questsByPlayer[playerName][tagName] then
-                        questsByPlayer[playerName][tagName] = {}
+                local category = GetQuestCategory(questInfo, questTagInfo)
+
+                if category ~= "Hidden" then
+                    local tracked = C_QuestLog.GetQuestWatchType and C_QuestLog.GetQuestWatchType(questID) ~= nil
+                    local ready = (C_QuestLog.IsComplete and C_QuestLog.IsComplete(questID))
+                        or (questInfo.isComplete ~= nil and questInfo.isComplete)
+
+                    if not questsByPlayer[playerName][category] then
+                        questsByPlayer[playerName][category] = {}
                     end
-                    
-                    table.insert(questsByPlayer[playerName][tagName], {id = questID, title = title, tracked = trackText, inlog = "Yes", ready = readyText, tag = questTagInfo, category = detailedCategory, isLocal = true})
-                end
-                if shiftDown and not silentRefresh then
-                    local chatLine = string.format("%d - %s (Tracked:%s Ready:%s)", questID, title, trackText, readyText)
-                    print("QuestCoop:", chatLine)
+                    table.insert(questsByPlayer[playerName][category], {
+                        id = questID, title = title,
+                        tracked = tracked, ready = ready,
+                        tag = questTagInfo, category = category,
+                        isCampaign = questInfo.campaignID ~= nil,
+                        isLocal = true,
+                    })
+
+                    if shiftDown then
+                        print(string.format("QuestCoop: %d - %s [%s]%s", questID, title, category, questInfo.campaignID and " [Campaign]" or ""))
+                    end
                 end
             end
         end
     end
-    
-    -- Now collect party members' quests (excluding local player to avoid duplication)
+
+    -- Collect party members' quests
     if IsInGroup() then
         for i = 1, GetNumGroupMembers() do
             local unit = (IsInRaid() and "raid" or "party") .. i
             local partyMember = UnitName(unit)
-            
-            -- Skip if this is the local player or invalid unit
             if partyMember and ShortName(partyMember) ~= ShortName(playerName) then
                 questsByPlayer[partyMember] = {}
-                
-                -- Check all local player's quests to see if party member has them
-                for i = 1, numEntries do
-                    local questInfo = C_QuestLog.GetInfo(i)
+                for j = 1, numEntries do
+                    local questInfo = C_QuestLog.GetInfo(j)
                     if questInfo and not questInfo.isHeader then
                         local questID = questInfo.questID
                         if questID then
                             local questData = GetPartyMemberQuestData(unit, questID)
                             if questData and questData.has then
-                                local title = questInfo.title or ("(Quest " .. questID .. ")")
-                                
-                                -- Try to get tag info from our own quest log if we have this quest
                                 local questTagInfo = C_QuestLog.GetQuestTagInfo and C_QuestLog.GetQuestTagInfo(questID)
-                                local tagName = questTagInfo and questTagInfo.tagName or "No Tag"
-                                
-                                -- Skip hidden quests for party members too
-                                if not (questTagInfo and questTagInfo.tagName and questTagInfo.tagName:lower() == "hidden quest") then
-                                    -- Initialize tag group if needed
-                                    if not questsByPlayer[partyMember][tagName] then
-                                        questsByPlayer[partyMember][tagName] = {}
+                                local category = GetQuestCategory(questInfo, questTagInfo)
+                                if category ~= "Hidden" then
+                                    if not questsByPlayer[partyMember][category] then
+                                        questsByPlayer[partyMember][category] = {}
                                     end
-                                    
-                                    table.insert(questsByPlayer[partyMember][tagName], {id = questID, title = title, tracked = "?", inlog = "Yes", ready = "?", tag = questTagInfo, category = "", isLocal = false})
+                                    local title = questInfo.title or ("Quest " .. questID)
+                                    table.insert(questsByPlayer[partyMember][category], {
+                                        id = questID, title = title,
+                                        tracked = false, ready = false,
+                                        tag = questTagInfo, category = category,
+                                        isCampaign = questInfo.campaignID ~= nil,
+                                        isLocal = false,
+                                    })
                                 end
                             end
                         end
@@ -542,118 +573,92 @@ function PrintQuestIDs(silentRefresh)
             end
         end
     end
-    
-    -- Build a list of all party members (including local player)
+
+    -- Build party member list and find shared quests
     local allPartyMembers = {}
-    for member, _ in pairs(questsByPlayer) do
-        table.insert(allPartyMembers, member)
-    end
+    for member in pairs(questsByPlayer) do table.insert(allPartyMembers, member) end
     local partySize = #allPartyMembers
-    
-    -- Identify shared quests (quests that ALL party members have)
-    local sharedQuestsByTag = {}
+
+    local sharedQuestsByCategory = {}
     if partySize > 1 then
-        -- Get all quest IDs from the first player
         local allQuestIDs = {}
-        for tagName, quests in pairs(questsByPlayer[allPartyMembers[1]]) do
+        for category, quests in pairs(questsByPlayer[allPartyMembers[1]]) do
             for _, quest in ipairs(quests) do
-                allQuestIDs[quest.id] = {tagName = tagName, quest = quest}
+                allQuestIDs[quest.id] = {category = category, quest = quest}
             end
         end
-        
-        -- Check which quests exist in ALL players' quest logs
-        for questID, questInfo in pairs(allQuestIDs) do
+        for questID, info in pairs(allQuestIDs) do
             local sharedByAll = true
             for i = 2, partySize do
                 local member = allPartyMembers[i]
                 local hasQuest = false
                 for _, quests in pairs(questsByPlayer[member]) do
-                    for _, quest in ipairs(quests) do
-                        if quest.id == questID then
-                            hasQuest = true
-                            break
-                        end
+                    for _, q in ipairs(quests) do
+                        if q.id == questID then hasQuest = true; break end
                     end
                     if hasQuest then break end
                 end
-                if not hasQuest then
-                    sharedByAll = false
-                    break
-                end
+                if not hasQuest then sharedByAll = false; break end
             end
-            
             if sharedByAll then
-                local tagName = questInfo.tagName
-                if not sharedQuestsByTag[tagName] then
-                    sharedQuestsByTag[tagName] = {}
-                end
-                table.insert(sharedQuestsByTag[tagName], questInfo.quest)
+                local cat = info.category
+                if not sharedQuestsByCategory[cat] then sharedQuestsByCategory[cat] = {} end
+                table.insert(sharedQuestsByCategory[cat], info.quest)
             end
         end
     end
-    
+
     -- Remove shared quests from individual player lists
-    for questTag, sharedQuests in pairs(sharedQuestsByTag) do
-        for _, sharedQuest in ipairs(sharedQuests) do
-            for member, questsByTag in pairs(questsByPlayer) do
-                if questsByTag[questTag] then
-                    for i = #questsByTag[questTag], 1, -1 do
-                        if questsByTag[questTag][i].id == sharedQuest.id then
-                            table.remove(questsByTag[questTag], i)
+    for cat, sharedQuests in pairs(sharedQuestsByCategory) do
+        for _, sq in ipairs(sharedQuests) do
+            for member, questsByCategory in pairs(questsByPlayer) do
+                if questsByCategory[cat] then
+                    for i = #questsByCategory[cat], 1, -1 do
+                        if questsByCategory[cat][i].id == sq.id then
+                            table.remove(questsByCategory[cat], i)
                         end
                     end
-                    -- Clean up empty tag groups
-                    if #questsByTag[questTag] == 0 then
-                        questsByTag[questTag] = nil
-                    end
+                    if #questsByCategory[cat] == 0 then questsByCategory[cat] = nil end
                 end
             end
         end
     end
-    
-    -- Clear previous row frames / fontstrings
+
+    -- Clear previous UI elements
     for _, fs in ipairs(questScrollChild.lines) do fs:Hide() end
     wipe(questScrollChild.lines)
 
-    -- Column layout constants (checkbox | id | title)
-    local COL_CHECK_X = 2
-    local COL_ID_X = 22
-    local COL_TITLE_X = 82
+    -- Column layout constants
+    local COL_TRACK_X = 2
+    local COL_ID_X    = 54
+    local COL_TITLE_X = 106
 
-    -- Precompute leader/untracked state once per render pass
     local selfName = ShortName(UnitName("player"))
     local isLeader = (GetQuestCoopLeader() == selfName)
-    local untrackedSet = GetEffectiveUntrackedQuests()
-    
-    -- Adjust row height and spacing based on text size
+
     local textSize = GetSetting("textSize")
-    local ROW_HEIGHT = (textSize == "small" and 14) or (textSize == "large" and 18) or 14
+    local ROW_HEIGHT          = (textSize == "small" and 14) or (textSize == "large" and 18) or 14
     local PLAYER_HEADING_HEIGHT = (textSize == "large" and 26) or 22
-    local SUBHEADING_HEIGHT = (textSize == "large" and 20) or 18
+    local SUBHEADING_HEIGHT   = (textSize == "large" and 20) or 18
     local yOff = -2
-    
-    -- Sort players: local player first, then others alphabetically
+
     local sortedPlayers = {}
-    for playerName, _ in pairs(questsByPlayer) do
-        table.insert(sortedPlayers, playerName)
-    end
+    for p in pairs(questsByPlayer) do table.insert(sortedPlayers, p) end
     table.sort(sortedPlayers, function(a, b)
-        local localPlayer = UnitName("player")
-        if a == localPlayer then return true end
-        if b == localPlayer then return false end
+        if a == playerName then return true end
+        if b == playerName then return false end
         return a < b
     end)
-    
-    -- Get font sizes based on settings
+
     local fontSmall, fontNormal, fontLarge = GetFontSize()
-    
-    -- Header row with column labels
-    local headerCheck = questScrollChild:CreateFontString(nil, "OVERLAY", fontSmall)
-    headerCheck:SetPoint("TOPLEFT", COL_CHECK_X, yOff)
-    headerCheck:SetJustifyH("LEFT")
-    headerCheck:SetTextColor(0.7, 0.7, 0.7)
-    headerCheck:SetText("Skip")
-    table.insert(questScrollChild.lines, headerCheck)
+
+    -- Column headers
+    local headerTrack = questScrollChild:CreateFontString(nil, "OVERLAY", fontSmall)
+    headerTrack:SetPoint("TOPLEFT", COL_TRACK_X, yOff)
+    headerTrack:SetJustifyH("LEFT")
+    headerTrack:SetTextColor(0.7, 0.7, 0.7)
+    headerTrack:SetText("Track")
+    table.insert(questScrollChild.lines, headerTrack)
 
     local headerID = questScrollChild:CreateFontString(nil, "OVERLAY", fontNormal)
     headerID:SetPoint("TOPLEFT", COL_ID_X, yOff)
@@ -666,202 +671,79 @@ function PrintQuestIDs(silentRefresh)
     headerTitle:SetJustifyH("LEFT")
     headerTitle:SetText("Title")
     table.insert(questScrollChild.lines, headerTitle)
-    
+
     yOff = yOff - ROW_HEIGHT - 4
-    
-    -- First, render shared quests section if there are any
-    local sharedQuestCount = 0
-    for _, quests in pairs(sharedQuestsByTag) do
-        sharedQuestCount = sharedQuestCount + #quests
-    end
-    
-    if sharedQuestCount > 0 then
-        -- Create shared section heading
-        local sharedHeading = questScrollChild:CreateFontString(nil, "OVERLAY", fontLarge)
-        sharedHeading:SetPoint("TOPLEFT", 0, yOff)
-        sharedHeading:SetJustifyH("LEFT")
-        sharedHeading:SetTextColor(0.5, 0.8, 1) -- Light blue for shared quests
-        sharedHeading:SetText(string.format("Shared by All (%d players) - %d quests", partySize, sharedQuestCount))
-        table.insert(questScrollChild.lines, sharedHeading)
-        yOff = yOff - PLAYER_HEADING_HEIGHT
-        
-        -- Sort tags alphabetically
-        local sortedSharedTags = {}
-        for tagName, _ in pairs(sharedQuestsByTag) do
-            table.insert(sortedSharedTags, tagName)
-        end
-        table.sort(sortedSharedTags)
-        
-        -- Render shared quests grouped by tag
-        for _, tagName in ipairs(sortedSharedTags) do
-            local questsInTag = sharedQuestsByTag[tagName]
-            
-            -- Create subheading for this tag
-            local subheading = questScrollChild:CreateFontString(nil, "OVERLAY", fontNormal)
-            subheading:SetPoint("TOPLEFT", 10, yOff)
-            subheading:SetJustifyH("LEFT")
-            subheading:SetTextColor(1, 0.82, 0) -- Gold color for subheadings
-            subheading:SetText(string.format("%s (%d)", tagName, #questsInTag))
-            table.insert(questScrollChild.lines, subheading)
-            yOff = yOff - SUBHEADING_HEIGHT
-            
-            -- Render each shared quest under this tag
-            for _, row in ipairs(questsInTag) do
-        -- Untrack checkbox
-        local cb = CreateFrame("CheckButton", nil, questScrollChild, "UICheckButtonTemplate")
-        cb:SetSize(16, 16)
-        cb:SetPoint("TOPLEFT", COL_CHECK_X, yOff + 1)
-        cb:SetChecked(untrackedSet[row.id] == true)
+
+    -- Helper: render the multi-state tracking mode button for a quest row
+    local function RenderTrackButton(questID, rowYOff)
+        local mode = GetEffectiveTrackingMode(questID) or "auto"
+        local col = TRACK_MODE_COLORS[mode]
+
+        local btn = CreateFrame("Button", nil, questScrollChild)
+        btn:SetSize(50, ROW_HEIGHT + 2)
+        btn:SetPoint("TOPLEFT", COL_TRACK_X, rowYOff + 1)
+
+        local bg = btn:CreateTexture(nil, "BACKGROUND")
+        bg:SetAllPoints()
+        bg:SetColorTexture(col[1] * 0.2, col[2] * 0.2, col[3] * 0.2, 0.8)
+
+        btn:SetHighlightTexture("Interface\\Buttons\\UI-Common-MouseHilight", "ADD")
+
+        local fs = btn:CreateFontString(nil, "OVERLAY", fontSmall)
+        fs:SetAllPoints()
+        fs:SetJustifyH("CENTER")
+        fs:SetTextColor(col[1], col[2], col[3])
+        fs:SetText(TRACK_MODE_LABELS[mode])
+
         if isLeader then
-            cb:SetScript("OnClick", function(self)
-                SetQuestUntracked(row.id, self:GetChecked())
+            btn:SetScript("OnClick", function()
+                local current = GetEffectiveTrackingMode(questID) or "auto"
+                local next = TRACK_MODE_CYCLE[current]
+                SetQuestTrackingMode(questID, next == "auto" and nil or next)
+                AutoSyncQuestTracking()
                 RefreshQuestWindowIfVisible()
             end)
-        else
-            cb:SetEnabled(false)
         end
-        table.insert(questScrollChild.lines, cb)
 
-        -- ID cell
-        local idFS = questScrollChild:CreateFontString(nil, "OVERLAY", fontSmall)
-        idFS:SetPoint("TOPLEFT", COL_ID_X, yOff)
-        idFS:SetJustifyH("LEFT")
-        idFS:SetText(row.id)
-        table.insert(questScrollChild.lines, idFS)
-
-        -- Title cell
-        local titleFS = questScrollChild:CreateFontString(nil, "OVERLAY", fontNormal)
-        titleFS:SetPoint("TOPLEFT", COL_TITLE_X, yOff)
-        titleFS:SetJustifyH("LEFT")
-        titleFS:SetTextColor(1, 1, 1)
-        titleFS:SetText(row.title)
-        titleFS.fullTitle = row.title
-        table.insert(questScrollChild.lines, titleFS)
-
-        -- Mouseover tooltip
-        local rowButton = CreateFrame("Button", nil, questScrollChild)
-        rowButton:SetPoint("TOPLEFT", idFS, "TOPLEFT", -2, 2)
-        rowButton:SetPoint("BOTTOMRIGHT", titleFS, "BOTTOMRIGHT", 2, -2)
-        rowButton:RegisterForClicks("LeftButtonUp", "RightButtonUp")
-        rowButton:SetScript("OnClick", function(self, button)
-            if button == "RightButton" then
-                MenuUtil.CreateContextMenu(UIParent, function(owner, rootDescription)
-                    rootDescription:CreateTitle(row.title)
-                    rootDescription:CreateButton("Share Quest", function()
-                        C_QuestLog.SetSelectedQuest(row.id)
-                        QuestLogPushQuest()
-                    end)
-                    rootDescription:CreateButton("Cancel", function() end)
-                end)
-            end
-        end)
-        rowButton:SetScript("OnEnter", function()
-            GameTooltip:SetOwner(rowButton, "ANCHOR_CURSOR")
-            GameTooltip:AddLine(row.fullTitle or row.title, 1,1,1, true)
-            GameTooltip:AddLine(string.format("Quest ID: %d", row.id), 0.9,0.9,0.9)
-            GameTooltip:AddLine("Shared by all party members", 0.5,0.8,1)
-            if row.category and row.category ~= "" then
-                GameTooltip:AddLine("Category: " .. tostring(row.category), 0.8,0.8,0.8)
-            end
-            if row.tag and row.tag.tagName then
-                GameTooltip:AddLine("Tag: " .. row.tag.tagName, 0.8,0.8,0.8)
+        btn:SetScript("OnEnter", function(self)
+            GameTooltip:SetOwner(self, "ANCHOR_CURSOR")
+            GameTooltip:AddLine("Quest Tracking Mode", 1, 1, 1)
+            GameTooltip:AddLine("Auto: smart selection by priority", 0.7, 0.7, 0.7)
+            GameTooltip:AddLine("Always: always kept in tracker", 0.3, 1, 0.3)
+            GameTooltip:AddLine("Never: never tracked", 1, 0.4, 0.4)
+            if isLeader then
+                GameTooltip:AddLine("Click to cycle", 1, 0.82, 0)
+            else
+                GameTooltip:AddLine("Only the QuestCoop leader can change modes", 0.6, 0.6, 0.6)
             end
             GameTooltip:Show()
         end)
-        rowButton:SetScript("OnLeave", function() GameTooltip:Hide() end)
-        table.insert(questScrollChild.lines, rowButton)
+        btn:SetScript("OnLeave", function() GameTooltip:Hide() end)
 
-        yOff = yOff - ROW_HEIGHT - 2
-            end
-            
-            -- Add spacing after each tag group
-            yOff = yOff - 6
-        end
-        
-        -- Add spacing after shared section
-        yOff = yOff - 15
+        table.insert(questScrollChild.lines, btn)
     end
-    
-    -- Then render individual player quests (excluding shared)
-    for _, playerDisplayName in ipairs(sortedPlayers) do
-        local questsByTag = questsByPlayer[playerDisplayName]
-        
-        -- Count total quests for this player
-        local totalQuests = 0
-        for _, quests in pairs(questsByTag) do
-            totalQuests = totalQuests + #quests
-        end
-        
-        -- Only display players with quests
-        if totalQuests > 0 then
-            -- Create player name heading
-            local playerHeading = questScrollChild:CreateFontString(nil, "OVERLAY", fontLarge)
-            playerHeading:SetPoint("TOPLEFT", 0, yOff)
-            playerHeading:SetJustifyH("LEFT")
-            playerHeading:SetTextColor(0.3, 1, 0.3) -- Bright green for player names
-            local displayName = ShortName(playerDisplayName)
-            if playerDisplayName == UnitName("player") then
-                displayName = displayName .. " (You)"
-            end
-            local questLabel = totalQuests == 1 and "unique quest" or "unique quests"
-            playerHeading:SetText(string.format("%s - %d %s", displayName, totalQuests, questLabel))
-            table.insert(questScrollChild.lines, playerHeading)
-            yOff = yOff - PLAYER_HEADING_HEIGHT
-            
-            -- Sort tags alphabetically for consistent display
-            local sortedTags = {}
-            for tagName, _ in pairs(questsByTag) do
-                table.insert(sortedTags, tagName)
-            end
-            table.sort(sortedTags)
-            
-            -- Render quests grouped by tag within this player
-            for _, tagName in ipairs(sortedTags) do
-                local questsInTag = questsByTag[tagName]
-                
-                -- Create subheading for this tag
-                local subheading = questScrollChild:CreateFontString(nil, "OVERLAY", fontNormal)
-                subheading:SetPoint("TOPLEFT", 10, yOff)
-                subheading:SetJustifyH("LEFT")
-                subheading:SetTextColor(1, 0.82, 0) -- Gold color for subheadings
-                subheading:SetText(string.format("%s (%d)", tagName, #questsInTag))
-                table.insert(questScrollChild.lines, subheading)
-                yOff = yOff - SUBHEADING_HEIGHT
-                
-                -- Render each quest under this tag
-                for _, row in ipairs(questsInTag) do
-        -- Untrack checkbox
-        local cb = CreateFrame("CheckButton", nil, questScrollChild, "UICheckButtonTemplate")
-        cb:SetSize(16, 16)
-        cb:SetPoint("TOPLEFT", COL_CHECK_X, yOff + 1)
-        cb:SetChecked(untrackedSet[row.id] == true)
-        if isLeader then
-            cb:SetScript("OnClick", function(self)
-                SetQuestUntracked(row.id, self:GetChecked())
-                RefreshQuestWindowIfVisible()
-            end)
-        else
-            cb:SetEnabled(false)
-        end
-        table.insert(questScrollChild.lines, cb)
 
-        -- ID cell
+    -- Helper: render a single quest row (track button + id + title + tooltip)
+    local function RenderQuestRow(row, rowYOff, tooltipExtraFn)
+        RenderTrackButton(row.id, rowYOff)
+
         local idFS = questScrollChild:CreateFontString(nil, "OVERLAY", fontSmall)
-        idFS:SetPoint("TOPLEFT", COL_ID_X, yOff)
+        idFS:SetPoint("TOPLEFT", COL_ID_X, rowYOff)
         idFS:SetJustifyH("LEFT")
         idFS:SetText(row.id)
         table.insert(questScrollChild.lines, idFS)
 
-        -- Title cell
         local titleFS = questScrollChild:CreateFontString(nil, "OVERLAY", fontNormal)
-        titleFS:SetPoint("TOPLEFT", COL_TITLE_X, yOff)
+        titleFS:SetPoint("TOPLEFT", COL_TITLE_X, rowYOff)
         titleFS:SetJustifyH("LEFT")
-        titleFS:SetTextColor(1, 1, 1)
+        if row.isCampaign then
+            titleFS:SetTextColor(1, 0.82, 0) -- gold for campaign quests
+        else
+            titleFS:SetTextColor(1, 1, 1)
+        end
         titleFS:SetText(row.title)
-        titleFS.fullTitle = row.title
         table.insert(questScrollChild.lines, titleFS)
 
-        -- Mouseover tooltip region
         local rowButton = CreateFrame("Button", nil, questScrollChild)
         rowButton:SetPoint("TOPLEFT", idFS, "TOPLEFT", -2, 2)
         rowButton:SetPoint("BOTTOMRIGHT", titleFS, "BOTTOMRIGHT", 2, -2)
@@ -880,18 +762,17 @@ function PrintQuestIDs(silentRefresh)
         end)
         rowButton:SetScript("OnEnter", function()
             GameTooltip:SetOwner(rowButton, "ANCHOR_CURSOR")
-            GameTooltip:AddLine(row.fullTitle or row.title, 1,1,1, true)
-            GameTooltip:AddLine(string.format("Quest ID: %d", row.id), 0.9,0.9,0.9)
-            if row.category and row.category ~= "" then
-                GameTooltip:AddLine("Category: " .. tostring(row.category), 0.8,0.8,0.8)
+            GameTooltip:AddLine(row.title, 1, 1, 1, true)
+            GameTooltip:AddLine(string.format("Quest ID: %d", row.id), 0.9, 0.9, 0.9)
+            GameTooltip:AddLine("Category: " .. row.category, 0.8, 0.8, 0.8)
+            if row.isCampaign then
+                GameTooltip:AddLine("Campaign Quest", 1, 0.82, 0)
             end
-            if row.tag and row.tag.tagName then
-                GameTooltip:AddLine("Tag: " .. row.tag.tagName, 0.8,0.8,0.8)
-            end
+            if tooltipExtraFn then tooltipExtraFn() end
             if IsInGroup() then
                 local hasMembers = {}
-                for i = 1, GetNumGroupMembers() do
-                    local unit = (IsInRaid() and "raid" or "party") .. i
+                for j = 1, GetNumGroupMembers() do
+                    local unit = (IsInRaid() and "raid" or "party") .. j
                     local memberName = UnitName(unit)
                     if memberName then
                         local questData = GetPartyMemberQuestData(unit, row.id)
@@ -900,59 +781,148 @@ function PrintQuestIDs(silentRefresh)
                         end
                     end
                 end
-                local function fmt(list)
-                    if #list == 0 then return "None" end
-                    table.sort(list)
-                    return table.concat(list, ", ")
+                if #hasMembers > 0 then
+                    table.sort(hasMembers)
+                    GameTooltip:AddLine("Has: " .. table.concat(hasMembers, ", "), 0.7, 0.9, 0.7)
                 end
-                GameTooltip:AddLine("Has: " .. fmt(hasMembers), 0.7,0.9,0.7)
             end
             GameTooltip:Show()
         end)
         rowButton:SetScript("OnLeave", function() GameTooltip:Hide() end)
         table.insert(questScrollChild.lines, rowButton)
+    end
 
-        yOff = yOff - ROW_HEIGHT - 2
+    -- Shared quests section
+    local sharedQuestCount = 0
+    for _, quests in pairs(sharedQuestsByCategory) do sharedQuestCount = sharedQuestCount + #quests end
+
+    if sharedQuestCount > 0 then
+        local sharedHeading = questScrollChild:CreateFontString(nil, "OVERLAY", fontLarge)
+        sharedHeading:SetPoint("TOPLEFT", 0, yOff)
+        sharedHeading:SetJustifyH("LEFT")
+        sharedHeading:SetTextColor(0.5, 0.8, 1)
+        sharedHeading:SetText(string.format("Shared by All (%d) — %d quest%s", partySize, sharedQuestCount, sharedQuestCount ~= 1 and "s" or ""))
+        table.insert(questScrollChild.lines, sharedHeading)
+        yOff = yOff - PLAYER_HEADING_HEIGHT
+
+        local sortedSharedCats = {}
+        for cat in pairs(sharedQuestsByCategory) do table.insert(sortedSharedCats, cat) end
+        table.sort(sortedSharedCats)
+
+        for _, cat in ipairs(sortedSharedCats) do
+            local quests = sharedQuestsByCategory[cat]
+            local subheading = questScrollChild:CreateFontString(nil, "OVERLAY", fontNormal)
+            subheading:SetPoint("TOPLEFT", 10, yOff)
+            subheading:SetJustifyH("LEFT")
+            subheading:SetTextColor(1, 0.82, 0)
+            subheading:SetText(string.format("%s (%d)", cat, #quests))
+            table.insert(questScrollChild.lines, subheading)
+            yOff = yOff - SUBHEADING_HEIGHT
+
+            for _, row in ipairs(quests) do
+                RenderQuestRow(row, yOff, function()
+                    GameTooltip:AddLine("Shared by all party members", 0.5, 0.8, 1)
+                end)
+                yOff = yOff - ROW_HEIGHT - 2
+            end
+            yOff = yOff - 6
         end
-        
-        -- Add spacing after each tag group
-        yOff = yOff - 6
-            end -- end for tags loop
-            
-            -- Add spacing after each player
+        yOff = yOff - 15
+    end
+
+    -- Individual player sections
+    for _, pName in ipairs(sortedPlayers) do
+        local questsByCategory = questsByPlayer[pName]
+        local totalQuests = 0
+        for _, quests in pairs(questsByCategory) do totalQuests = totalQuests + #quests end
+
+        if totalQuests > 0 then
+            local playerHeading = questScrollChild:CreateFontString(nil, "OVERLAY", fontLarge)
+            playerHeading:SetPoint("TOPLEFT", 0, yOff)
+            playerHeading:SetJustifyH("LEFT")
+            playerHeading:SetTextColor(0.3, 1, 0.3)
+            local displayName = ShortName(pName)
+            if pName == playerName then displayName = displayName .. " (You)" end
+            playerHeading:SetText(string.format("%s — %d unique quest%s", displayName, totalQuests, totalQuests ~= 1 and "s" or ""))
+            table.insert(questScrollChild.lines, playerHeading)
+            yOff = yOff - PLAYER_HEADING_HEIGHT
+
+            local sortedCats = {}
+            for cat in pairs(questsByCategory) do table.insert(sortedCats, cat) end
+            table.sort(sortedCats)
+
+            for _, cat in ipairs(sortedCats) do
+                local quests = questsByCategory[cat]
+                local subheading = questScrollChild:CreateFontString(nil, "OVERLAY", fontNormal)
+                subheading:SetPoint("TOPLEFT", 10, yOff)
+                subheading:SetJustifyH("LEFT")
+                subheading:SetTextColor(1, 0.82, 0)
+                subheading:SetText(string.format("%s (%d)", cat, #quests))
+                table.insert(questScrollChild.lines, subheading)
+                yOff = yOff - SUBHEADING_HEIGHT
+
+                for _, row in ipairs(quests) do
+                    RenderQuestRow(row, yOff)
+                    yOff = yOff - ROW_HEIGHT - 2
+                end
+                yOff = yOff - 6
+            end
             yOff = yOff - 10
-        end -- end if totalQuests > 0
-    end -- end for players loop
+        end
+    end
 
     local totalHeight = (-yOff) + 4
     questScrollChild:SetHeight(totalHeight)
-    questScrollChild:SetWidth(math.max(questScrollFrame:GetWidth(), 200))
+    questScrollChild:SetWidth(math.max(questScrollFrame:GetWidth(), 220))
     questWindow:Show()
 end
 
--- Recently Completed Party Quests window
-local recentlyCompletedWindow, rcScrollFrame, rcScrollChild
+-- QC Alerts window (replaces "Recently Completed Party Quests")
+local qcAlertsWindow, qcAlertsScrollFrame, qcAlertsScrollChild
 
-local function RefreshRecentlyCompletedWindow()
-    if not recentlyCompletedWindow then return end
-    if rcScrollChild.lines then
-        for _, el in ipairs(rcScrollChild.lines) do el:Hide() end
-        wipe(rcScrollChild.lines)
+RefreshQCAlertsWindow = function()
+    if not qcAlertsWindow then return end
+    if qcAlertsScrollChild.lines then
+        for _, el in ipairs(qcAlertsScrollChild.lines) do el:Hide() end
+        wipe(qcAlertsScrollChild.lines)
     end
-    rcScrollChild.lines = {}
-
-    local count = 0
-    for _ in pairs(recentlyCompletedQuests) do count = count + 1 end
-    if count == 0 then
-        recentlyCompletedWindow:Hide()
-        return
-    end
+    qcAlertsScrollChild.lines = {}
 
     local yOff = -2
-    for questID, data in pairs(recentlyCompletedQuests) do
-        local btn = CreateFrame("Button", nil, rcScrollChild)
+    local hasEntries = false
+
+    -- Not-shared alerts (always-track quests missing from some party members)
+    for questID, data in pairs(notSharedAlerts) do
+        hasEntries = true
+        local btn = CreateFrame("Button", nil, qcAlertsScrollChild)
         btn:SetPoint("TOPLEFT", 8, yOff)
-        btn:SetSize(280, 18)
+        btn:SetSize(340, 18)
+        btn:RegisterForClicks("RightButtonUp")
+        btn:SetScript("OnClick", function()
+            notSharedAlerts[questID] = nil
+            RefreshQCAlertsWindow()
+        end)
+        btn:SetScript("OnEnter", function(self)
+            GameTooltip:SetOwner(self, "ANCHOR_CURSOR")
+            GameTooltip:SetText("Right-click to dismiss", 1, 1, 1)
+            GameTooltip:Show()
+        end)
+        btn:SetScript("OnLeave", function() GameTooltip:Hide() end)
+
+        local line = btn:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+        line:SetAllPoints()
+        line:SetJustifyH("LEFT")
+        line:SetText(string.format("|cffff9900[!]|r %s — not shared with full party", data.title))
+        table.insert(qcAlertsScrollChild.lines, btn)
+        yOff = yOff - 18
+    end
+
+    -- Recently completed quests
+    for questID, data in pairs(recentlyCompletedQuests) do
+        hasEntries = true
+        local btn = CreateFrame("Button", nil, qcAlertsScrollChild)
+        btn:SetPoint("TOPLEFT", 8, yOff)
+        btn:SetSize(340, 18)
         btn:RegisterForClicks("RightButtonUp")
         btn:SetScript("OnClick", function()
             RemoveQuestFromRecentlyCompleted(questID)
@@ -969,58 +939,65 @@ local function RefreshRecentlyCompletedWindow()
         line:SetJustifyH("LEFT")
         line:SetTextColor(1, 1, 1)
         line:SetText(string.format("%s  |cff90ee90(by %s)|r", data.title, table.concat(data.completors, ", ")))
-
-        table.insert(rcScrollChild.lines, btn)
+        table.insert(qcAlertsScrollChild.lines, btn)
         yOff = yOff - 18
     end
-    rcScrollChild:SetHeight((-yOff) + 4)
+
+    qcAlertsScrollChild:SetHeight((-yOff) + 4)
+
+    if not hasEntries then
+        qcAlertsWindow:Hide()
+    end
 end
 
-local function CreateRecentlyCompletedWindow()
-    if recentlyCompletedWindow then return end
-    recentlyCompletedWindow = CreateFrame("Frame", "QuestCoopRecentlyCompletedWindow", UIParent, "BackdropTemplate")
-    recentlyCompletedWindow:SetSize(360, 200)
-    recentlyCompletedWindow:SetPoint("CENTER", 0, -120)
-    recentlyCompletedWindow:SetMovable(true)
-    recentlyCompletedWindow:EnableMouse(true)
-    recentlyCompletedWindow:RegisterForDrag("LeftButton")
-    recentlyCompletedWindow:SetScript("OnDragStart", function(self) self:StartMoving() end)
-    recentlyCompletedWindow:SetScript("OnDragStop", function(self) self:StopMovingOrSizing() end)
-    recentlyCompletedWindow:SetBackdrop({bgFile = "Interface/Tooltips/UI-Tooltip-Background", edgeFile = "Interface/Tooltips/UI-Tooltip-Border", tile = true, tileSize = 16, edgeSize = 16, insets = {left = 4, right = 4, top = 4, bottom = 4}})
-    recentlyCompletedWindow:SetBackdropColor(0, 0, 0, 0.85)
-    recentlyCompletedWindow:Hide()
+local function CreateQCAlertsWindow()
+    if qcAlertsWindow then return end
+    qcAlertsWindow = CreateFrame("Frame", "QuestCoopQCAlertsWindow", UIParent, "BackdropTemplate")
+    qcAlertsWindow:SetSize(380, 200)
+    qcAlertsWindow:SetPoint("CENTER", 0, -120)
+    qcAlertsWindow:SetMovable(true)
+    qcAlertsWindow:EnableMouse(true)
+    qcAlertsWindow:RegisterForDrag("LeftButton")
+    qcAlertsWindow:SetScript("OnDragStart", function(self) self:StartMoving() end)
+    qcAlertsWindow:SetScript("OnDragStop", function(self) self:StopMovingOrSizing() end)
+    qcAlertsWindow:SetBackdrop({bgFile = "Interface/Tooltips/UI-Tooltip-Background", edgeFile = "Interface/Tooltips/UI-Tooltip-Border", tile = true, tileSize = 16, edgeSize = 16, insets = {left = 4, right = 4, top = 4, bottom = 4}})
+    qcAlertsWindow:SetBackdropColor(0, 0, 0, 0.85)
+    qcAlertsWindow:Hide()
 
-    local title = recentlyCompletedWindow:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
+    local title = qcAlertsWindow:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
     title:SetPoint("TOP", 0, -10)
-    title:SetText("Recently Completed Party Quests")
+    title:SetText("QC Alerts")
 
-    local close = CreateFrame("Button", nil, recentlyCompletedWindow, "UIPanelCloseButton")
+    local close = CreateFrame("Button", nil, qcAlertsWindow, "UIPanelCloseButton")
     close:SetPoint("TOPRIGHT", 0, 0)
 
-    rcScrollFrame = CreateFrame("ScrollFrame", "QuestCoopRCScroll", recentlyCompletedWindow, "UIPanelScrollFrameTemplate")
-    rcScrollFrame:SetPoint("TOPLEFT", 16, -40)
-    rcScrollFrame:SetPoint("BOTTOMRIGHT", -30, 16)
+    qcAlertsScrollFrame = CreateFrame("ScrollFrame", "QuestCoopQCAlertsScroll", qcAlertsWindow, "UIPanelScrollFrameTemplate")
+    qcAlertsScrollFrame:SetPoint("TOPLEFT", 16, -40)
+    qcAlertsScrollFrame:SetPoint("BOTTOMRIGHT", -30, 16)
 
-    rcScrollChild = CreateFrame("Frame", nil, rcScrollFrame)
-    rcScrollChild:SetSize(300, 1)
-    rcScrollFrame:SetScrollChild(rcScrollChild)
-    rcScrollChild.lines = {}
+    qcAlertsScrollChild = CreateFrame("Frame", nil, qcAlertsScrollFrame)
+    qcAlertsScrollChild:SetSize(320, 1)
+    qcAlertsScrollFrame:SetScrollChild(qcAlertsScrollChild)
+    qcAlertsScrollChild.lines = {}
 end
 
-local function ShowRecentlyCompletedWindow()
-    CreateRecentlyCompletedWindow()
-    RefreshRecentlyCompletedWindow()
-    local count = 0
-    for _ in pairs(recentlyCompletedQuests) do count = count + 1 end
-    if count > 0 then recentlyCompletedWindow:Show() end
+ShowQCAlerts = function()
+    CreateQCAlertsWindow()
+    RefreshQCAlertsWindow()
+    local hasEntries = false
+    for _ in pairs(notSharedAlerts) do hasEntries = true; break end
+    if not hasEntries then
+        for _ in pairs(recentlyCompletedQuests) do hasEntries = true; break end
+    end
+    if hasEntries then qcAlertsWindow:Show() end
 end
 
-ToggleRecentlyCompletedWindow = function()
-    CreateRecentlyCompletedWindow()
-    if recentlyCompletedWindow:IsShown() then
-        recentlyCompletedWindow:Hide()
+ToggleQCAlertsWindow = function()
+    CreateQCAlertsWindow()
+    if qcAlertsWindow:IsShown() then
+        qcAlertsWindow:Hide()
     else
-        ShowRecentlyCompletedWindow()
+        ShowQCAlerts()
     end
 end
 
@@ -1031,41 +1008,37 @@ local function AddQuestToRecentlyCompleted(questID, title, completors, completor
             RemoveQuestFromRecentlyCompleted(questID)
         end
     end)
-    ShowRecentlyCompletedWindow()
+    ShowQCAlerts()
 end
 
-local function RemoveQuestFromRecentlyCompleted(questID)
+RemoveQuestFromRecentlyCompleted = function(questID)
     recentlyCompletedQuests[questID] = nil
     pendingCompletedQuests[questID] = nil
-    if recentlyCompletedWindow then RefreshRecentlyCompletedWindow() end
+    if qcAlertsWindow then RefreshQCAlertsWindow() end
 end
 
--- Minimap button creation
+-- Minimap button
 local minimapButton
 local function CreateMinimapButton()
     if minimapButton then return end
-    
+
     minimapButton = CreateFrame("Button", "QuestCoopMinimapButton", Minimap)
     minimapButton:SetSize(32, 32)
     minimapButton:SetFrameStrata("MEDIUM")
     minimapButton:SetFrameLevel(8)
     minimapButton:RegisterForClicks("LeftButtonUp", "RightButtonUp")
     minimapButton:SetHighlightTexture("Interface\\Minimap\\UI-Minimap-ZoomButton-Highlight")
-    
-    -- Icon texture
+
     local icon = minimapButton:CreateTexture(nil, "BACKGROUND")
     icon:SetSize(20, 20)
     icon:SetPoint("CENTER", 0, 1)
-    icon:SetTexture("Interface\\Icons\\INV_Misc_Note_01") -- Quest scroll icon
-    minimapButton.icon = icon
-    
-    -- Border
+    icon:SetTexture("Interface\\Icons\\INV_Misc_Note_01")
+
     local border = minimapButton:CreateTexture(nil, "OVERLAY")
     border:SetSize(52, 52)
     border:SetPoint("TOPLEFT")
     border:SetTexture("Interface\\Minimap\\MiniMap-TrackingBorder")
-    
-    -- Click handler
+
     minimapButton:SetScript("OnClick", function(self, button)
         if button == "LeftButton" then
             PrintQuestIDs()
@@ -1078,8 +1051,7 @@ local function CreateMinimapButton()
             end
         end
     end)
-    
-    -- Tooltip
+
     minimapButton:SetScript("OnEnter", function(self)
         GameTooltip:SetOwner(self, "ANCHOR_LEFT")
         GameTooltip:AddLine("Quest Co-op", 1, 1, 1)
@@ -1087,55 +1059,41 @@ local function CreateMinimapButton()
         GameTooltip:AddLine("Right-click: Settings", 0.5, 1, 0.5)
         GameTooltip:Show()
     end)
-    
-    minimapButton:SetScript("OnLeave", function(self)
-        GameTooltip:Hide()
-    end)
-    
-    -- Dragging functionality
+    minimapButton:SetScript("OnLeave", function() GameTooltip:Hide() end)
+
     minimapButton:SetMovable(true)
     minimapButton:EnableMouse(true)
     minimapButton:RegisterForDrag("LeftButton")
-    
+
     local function UpdatePosition()
         local angle = QuestCoopDB.minimapAngle or 225
         local x, y = math.cos(angle), math.sin(angle)
         minimapButton:SetPoint("CENTER", Minimap, "CENTER", x * 100, y * 100)
     end
-    
-    minimapButton:SetScript("OnDragStart", function(self)
-        self:LockHighlight()
-        self.isDragging = true
-    end)
-    
-    minimapButton:SetScript("OnDragStop", function(self)
-        self:UnlockHighlight()
-        self.isDragging = false
-    end)
-    
+
+    minimapButton:SetScript("OnDragStart", function(self) self:LockHighlight(); self.isDragging = true end)
+    minimapButton:SetScript("OnDragStop", function(self) self:UnlockHighlight(); self.isDragging = false end)
     minimapButton:SetScript("OnUpdate", function(self)
         if self.isDragging then
             local mx, my = Minimap:GetCenter()
             local px, py = GetCursorPosition()
             local scale = Minimap:GetEffectiveScale()
             px, py = px / scale, py / scale
-            
             local angle = math.atan2(py - my, px - mx)
             QuestCoopDB.minimapAngle = angle
             UpdatePosition()
         end
     end)
-    
+
     UpdatePosition()
 end
 
--- Create frame to handle events
+-- Event handler frame
 local frame = CreateFrame("Frame")
 frame:RegisterEvent("PLAYER_LOGIN")
 
--- Periodic timer for auto-syncing quest tracking
 local autoSyncTimer = 0
-local AUTO_SYNC_INTERVAL = 15 -- seconds
+local AUTO_SYNC_INTERVAL = 15
 
 frame:SetScript("OnUpdate", function(self, elapsed)
     autoSyncTimer = autoSyncTimer + elapsed
@@ -1147,24 +1105,27 @@ end)
 
 frame:SetScript("OnEvent", function(self, event, ...)
     if event == "PLAYER_LOGIN" then
-        -- Initialize settings
         if not QuestCoopDB then QuestCoopDB = {} end
-        if not QuestCoopDB.settings then
-            QuestCoopDB.settings = {}
-            for k, v in pairs(DEFAULT_SETTINGS) do
-                if QuestCoopDB.settings[k] == nil then
-                    QuestCoopDB.settings[k] = v
-                end
+        if not QuestCoopDB.settings then QuestCoopDB.settings = {} end
+        for k, v in pairs(DEFAULT_SETTINGS) do
+            if QuestCoopDB.settings[k] == nil then
+                QuestCoopDB.settings[k] = v
             end
         end
-        
-        -- Create settings panel
+        -- Migrate old untrackedQuests -> questTrackingMode "never"
+        if QuestCoopDB.untrackedQuests then
+            if not QuestCoopDB.questTrackingMode then QuestCoopDB.questTrackingMode = {} end
+            for questID in pairs(QuestCoopDB.untrackedQuests) do
+                if not QuestCoopDB.questTrackingMode[questID] then
+                    QuestCoopDB.questTrackingMode[questID] = "never"
+                end
+            end
+            QuestCoopDB.untrackedQuests = nil
+        end
+
         CreateSettingsPanel()
-        
-        -- Create minimap button
         CreateMinimapButton()
-        
-        -- Register slash command
+
         SLASH_QUESTCOOP1 = "/questcoop"
         SLASH_QUESTCOOP2 = "/qc"
         SlashCmdList["QUESTCOOP"] = function(msg)
@@ -1172,7 +1133,7 @@ frame:SetScript("OnEvent", function(self, event, ...)
             if msg == "settings" or msg == "config" or msg == "options" then
                 if InterfaceOptionsFrame_OpenToCategory then
                     InterfaceOptionsFrame_OpenToCategory(settingsPanel)
-                    InterfaceOptionsFrame_OpenToCategory(settingsPanel) -- Call twice for proper navigation
+                    InterfaceOptionsFrame_OpenToCategory(settingsPanel)
                 elseif Settings and Settings.OpenToCategory then
                     Settings.OpenToCategory(settingsPanel.name)
                 end
@@ -1180,44 +1141,53 @@ frame:SetScript("OnEvent", function(self, event, ...)
                 PrintQuestIDs()
             end
         end
-        
-        -- Register addon message prefix for leader sync
+
         C_ChatInfo.RegisterAddonMessagePrefix("QuestCoop")
 
-        -- Run initial auto-sync and leader/untracked broadcast after login
         C_Timer.After(2, function()
             AutoSyncQuestTracking()
             BroadcastLeaderPref()
-            BroadcastUntrackedQuests()
+            BroadcastTrackingModes()
+            BroadcastMaxTrack()
         end)
     end
-    -- Auto-refresh triggers
+
     if event == "QUEST_ACCEPTED" or event == "QUEST_REMOVED" or event == "QUEST_WATCH_LIST_CHANGED" or event == "QUEST_LOG_UPDATE" or event == "GROUP_ROSTER_UPDATE" or event == "QUEST_TURNED_IN" then
         RefreshQuestWindowIfVisible()
-        -- Also trigger auto-sync on these events
         AutoSyncQuestTracking()
     end
+
+    if event == "QUEST_ACCEPTED" then
+        local questID = ...
+        if questID then questLastActivity[questID] = GetTime() end
+    end
+
+    if event == "QUEST_WATCH_UPDATE" then
+        local questID = ...
+        if questID then questLastActivity[questID] = GetTime() end
+    end
+
     if event == "GROUP_ROSTER_UPDATE" then
         CleanupLeaderPrefs()
         C_Timer.After(1, BroadcastLeaderPref)
-        C_Timer.After(1.5, BroadcastUntrackedQuests)
+        C_Timer.After(1.5, function()
+            BroadcastTrackingModes()
+            BroadcastMaxTrack()
+        end)
     end
-    -- Monitor for quest share acceptance
+
     if event == "CHAT_MSG_SYSTEM" then
         local message = ...
-        -- ERR_QUEST_PUSH_SUCCESS_S is "%s accepted your quest."
-        -- Create a pattern from the global string
         local pattern = string.gsub(ERR_QUEST_PUSH_SUCCESS_S, "%%s", "(.+)")
         local characterName = string.match(message, pattern)
-        
         if characterName then
-            -- Wait 1 second then refresh auto-sync to pick up the newly shared quest
             C_Timer.After(1, function()
                 AutoSyncQuestTracking()
                 RefreshQuestWindowIfVisible()
             end)
         end
     end
+
     if event == "QUEST_TURNED_IN" then
         local questID = ...
         if questID then
@@ -1226,31 +1196,35 @@ frame:SetScript("OnEvent", function(self, event, ...)
             RemoveQuestFromRecentlyCompleted(questID)
         end
     end
+
     if event == "CHAT_MSG_ADDON" then
         local prefix, message, channel, sender = ...
         if prefix == "QuestCoop" then
+            -- LEADER_PREF
             local pref = message:match("^LEADER_PREF|(%d)$")
             if pref then
                 leaderPrefs[ShortName(sender)] = (pref == "1")
                 RefreshQuestWindowIfVisible()
-                -- If the leader changed, request their untracked list via a re-broadcast.
-                C_Timer.After(0.5, BroadcastUntrackedQuests)
+                C_Timer.After(0.5, function()
+                    BroadcastTrackingModes()
+                    BroadcastMaxTrack()
+                end)
             end
 
-            -- UNTRACKED_QUESTS: apply only when it comes from the current leader.
-            local untrackedPayload = message:match("^UNTRACKED_QUESTS|(.*)$")
-            if untrackedPayload then
+            -- TRACK_MODES: replaces UNTRACKED_QUESTS
+            local trackPayload = message:match("^TRACK_MODES|(.*)$")
+            if trackPayload then
                 local senderShort = ShortName(sender)
                 local leaderName = GetQuestCoopLeader()
                 local selfName2 = ShortName(UnitName("player"))
                 if senderShort == leaderName and leaderName ~= selfName2 then
-                    receivedUntrackedQuests = {}
-                    if untrackedPayload ~= "" then
-                        for idStr in untrackedPayload:gmatch("[^,]+") do
+                    receivedTrackingModes = {}
+                    if trackPayload ~= "" then
+                        for entry in trackPayload:gmatch("[^,]+") do
+                            local idStr, mode = entry:match("^(%d+):(.+)$")
                             local qid = tonumber(idStr)
-                            if qid then
-                                receivedUntrackedQuests[qid] = true
-                                if C_QuestLog.RemoveQuestWatch then C_QuestLog.RemoveQuestWatch(qid) end
+                            if qid and mode then
+                                receivedTrackingModes[qid] = mode
                             end
                         end
                     end
@@ -1259,7 +1233,19 @@ frame:SetScript("OnEvent", function(self, event, ...)
                 end
             end
 
-            -- QUEST_COMPLETED: another party member finished a quest.
+            -- MAX_TRACK: leader's max quests to track setting
+            local maxTrackStr = message:match("^MAX_TRACK|(%d+)$")
+            if maxTrackStr then
+                local senderShort = ShortName(sender)
+                local leaderName = GetQuestCoopLeader()
+                local selfName2 = ShortName(UnitName("player"))
+                if senderShort == leaderName and leaderName ~= selfName2 then
+                    receivedMaxTrack = tonumber(maxTrackStr)
+                    AutoSyncQuestTracking()
+                end
+            end
+
+            -- QUEST_COMPLETED: party member finished a quest
             local completedPayload = message:match("^QUEST_COMPLETED|(.+)$")
             if completedPayload then
                 local questIDStr, title = completedPayload:match("^(%d+)|(.*)$")
@@ -1267,15 +1253,13 @@ frame:SetScript("OnEvent", function(self, event, ...)
                 if questID and title and not selfCompletedQuests[questID] then
                     local senderShort = ShortName(sender)
                     if recentlyCompletedQuests[questID] then
-                        -- Already visible: add this completer if new
                         local data = recentlyCompletedQuests[questID]
                         if not data.completorSet[senderShort] then
                             data.completorSet[senderShort] = true
                             table.insert(data.completors, senderShort)
-                            RefreshRecentlyCompletedWindow()
+                            RefreshQCAlertsWindow()
                         end
                     elseif not pendingCompletedQuests[questID] then
-                        -- Start grace period, collecting all completors that arrive
                         pendingCompletedQuests[questID] = {title = title, completors = {senderShort}, completorSet = {[senderShort] = true}}
                         C_Timer.After(10, function()
                             if pendingCompletedQuests[questID] then
@@ -1287,7 +1271,6 @@ frame:SetScript("OnEvent", function(self, event, ...)
                             end
                         end)
                     else
-                        -- Already pending: add this completer to the pending batch
                         local pending = pendingCompletedQuests[questID]
                         if not pending.completorSet[senderShort] then
                             pending.completorSet[senderShort] = true
@@ -1300,7 +1283,7 @@ frame:SetScript("OnEvent", function(self, event, ...)
     end
 end)
 
--- Register quest-related events for auto refresh
+-- Register events
 frame:RegisterEvent("QUEST_ACCEPTED")
 frame:RegisterEvent("QUEST_REMOVED")
 frame:RegisterEvent("QUEST_WATCH_LIST_CHANGED")
@@ -1309,3 +1292,4 @@ frame:RegisterEvent("GROUP_ROSTER_UPDATE")
 frame:RegisterEvent("CHAT_MSG_SYSTEM")
 frame:RegisterEvent("CHAT_MSG_ADDON")
 frame:RegisterEvent("QUEST_TURNED_IN")
+frame:RegisterEvent("QUEST_WATCH_UPDATE")


### PR DESCRIPTION
- Add GetQuestCategory() replacing raw WoW tag usage; falls back to campaign, zone, or "General" when no tag is present
- Filter quests with category "Emissary Quest", "Island Weekly Quest", or "Hidden" from the QC window entirely
- Replace untracked checkbox ("Skip") with a 3-state cycling button: Auto / Always / Never — leader-only, syncs to party via TRACK_MODES
- Add maxQuestsToTrack setting (default 5) with slider in settings panel; leader's value syncs to party via MAX_TRACK message
- Rework AutoSyncQuestTracking: always-track quests fill slots first, remaining slots filled by scoring (campaign +3, recent activity +2, current zone +1); never-track and hidden quests are excluded
- Track quest activity via QUEST_ACCEPTED and QUEST_WATCH_UPDATE events
- Rename "Recently Completed Party Quests" window to "QC Alerts"
- Add not-shared alerts in QC Alerts when an "Always" track quest is missing from one or more party members
- Migrate old untrackedQuests DB entries to questTrackingMode "never"
- Auto-tracking now works solo (no longer bails out when not in party)
- Campaign quests rendered in gold in the quest list